### PR TITLE
JBTHR-32 QueuelessExecutor doesn't shrink with keepAliveTime

### DIFF
--- a/src/main/java/org/jboss/threads/QueuelessExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuelessExecutor.java
@@ -591,8 +591,8 @@ public final class QueuelessExecutor extends AbstractExecutorService implements 
         }
 
         private boolean awaitTimed(Condition condition, long idleSince) {
-            final long end = clipHigh(System.currentTimeMillis() + keepAliveTime);
-            long remaining = end - idleSince;
+            final long end = clipHigh(idleSince + keepAliveTime);
+            long remaining = end - System.currentTimeMillis();
             if (remaining < 0L) {
                 return false;
             }
@@ -671,7 +671,7 @@ public final class QueuelessExecutor extends AbstractExecutorService implements 
             } finally {
                 lock.lock();
                 try {
-                    if (stop && runningThreads.remove(thread) && runningThreads.isEmpty()) {
+                    if (runningThreads.remove(thread) && stop && runningThreads.isEmpty()) {
                         threadDeath.signalAll();
                         last = true;
                     }

--- a/src/test/java/org/jboss/threads/ThreadPoolTestCase.java
+++ b/src/test/java/org/jboss/threads/ThreadPoolTestCase.java
@@ -216,6 +216,35 @@ public final class ThreadPoolTestCase extends TestCase {
     }
 
     public void testQueuelessKeepAlive() throws InterruptedException {
+        // Test for https://issues.jboss.org/browse/JBTHR-32 QueuelessExecutor doesn't shrink with keepAliveTime
+        final QueuelessExecutor simpleQueuelessExecutor = new QueuelessExecutor(threadFactory, SimpleDirectExecutor.INSTANCE, null, 100L);
+        simpleQueuelessExecutor.setMaxThreads(1);
+        final Holder<Thread> thread1 = new Holder<Thread>(null);
+        simpleQueuelessExecutor.execute(new Runnable() {
+                boolean first = true;
+                public void run() {
+                    thread1.set(Thread.currentThread());
+                }
+            });
+        try {
+            Thread.sleep(500L);
+        } catch (InterruptedException ignore) { }
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Holder<Thread> thread2 = new Holder<Thread>(null);
+        simpleQueuelessExecutor.execute(new Runnable() {
+                public void run() {
+                    thread2.set(Thread.currentThread());
+                    latch.countDown();
+                }
+            });
+        latch.await(100L, TimeUnit.MILLISECONDS);
+        assertTrue("First task and second task should be executed on different threads", thread1.get() != thread2.get());
+        simpleQueuelessExecutor.shutdown();
+        assertTrue("Executor not shut down in 800ms", simpleQueuelessExecutor.awaitTermination(800L, TimeUnit.MILLISECONDS));
+        Thread.interrupted();
+    }
+
+    public void testQueuelessKeepAliveRepeating() throws InterruptedException {
         // Test for https://issues.jboss.org/browse/JBTHR-23 QueuelessExecutor repeats to execute previous runnable
         final QueuelessExecutor simpleQueuelessExecutor = new QueuelessExecutor(threadFactory, SimpleDirectExecutor.INSTANCE, null, 100L);
         simpleQueuelessExecutor.setMaxThreads(1);
@@ -287,3 +316,4 @@ public final class ThreadPoolTestCase extends TestCase {
         }
     }
 }
+


### PR DESCRIPTION
- Fix remaining calculation in awaitTimed() method
- Make sure to call runningThreads.remove() at the beginning of finally block in run() method
- Add test case for keepAliveTime shrinking
