### PR TITLE
Upgrade to JUnit 4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- It doesn't break existing JUnit 3 tests, all tests run fine
- Allows us to run single test like "mvn test -Dtest=ThreadPoolTestCase#testQueuelessKeepAlive"
