### PR TITLE
[WFLY-9742] Clear the TCCL to avoid classloader leaks

### DIFF
--- a/src/main/java/org/jboss/threads/JBossThreadFactory.java
+++ b/src/main/java/org/jboss/threads/JBossThreadFactory.java
@@ -111,6 +111,10 @@ public final class JBossThreadFactory implements ThreadFactory {
         }
         thread.setThreadNameInfo(nameInfo);
         thread.setName(nameInfo.format(thread, namePattern));
+        
+        // Clear the TCCL to avoid classloader leaks - see WFLY-9742
+        thread.setContextClassLoader(null);
+        
         if (initialPriority != null) thread.setPriority(initialPriority.intValue());
         if (daemon != null) thread.setDaemon(daemon.booleanValue());
         if (uncaughtExceptionHandler != null) thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);


### PR DESCRIPTION
As described in [WFLY-9742](https://issues.jboss.org/browse/WFLY-9742), this change ensures that any JBossThreads created by the JBossThreadFactory will not leak classloaders because of using the TCCL inherited by its parent thread.