### PR TITLE
JBTHR-71: Improve EnhancedQueueExecutor lock locality

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -53,6 +53,8 @@ import org.jboss.threads.management.ManageableThreadPoolExecutorService;
 import org.jboss.threads.management.StandardThreadPoolMXBean;
 import org.wildfly.common.Assert;
 import org.wildfly.common.lock.ExtendedLock;
+import org.wildfly.common.lock.Locks;
+import org.wildfly.common.lock.SpinLock;
 
 /**
  * A task-or-thread queue backed thread pool executor service.  Tasks are added in a FIFO manner, and consumers in a LIFO manner.
@@ -177,6 +179,20 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
      * The access control context of the creating thread.
      */
     private final AccessControlContext acc;
+
+    // =======================================================
+    // Locks
+    // =======================================================
+
+    /**
+     * The tail lock.  Only used if {@link #TAIL_LOCK} is {@code true}.
+     */
+    private final ExtendedLock tailLock = TAIL_LOCK ? TAIL_SPIN ? new SpinLock() : Locks.reentrantLock() : null;
+
+    /**
+     * The head lock.  Only used if {@link #HEAD_LOCK} is {@code true}.
+     */
+    private final ExtendedLock headLock = COMBINED_LOCK ? tailLock : HEAD_LOCK ? HEAD_SPIN ? new SpinLock() : Locks.reentrantLock() : null;
 
     // =======================================================
     // Current state fields

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase1.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase1.java
@@ -21,9 +21,6 @@ package org.jboss.threads;
 import static org.jboss.threads.JBossExecutors.unsafe;
 
 import org.wildfly.common.annotation.NotNull;
-import org.wildfly.common.lock.ExtendedLock;
-import org.wildfly.common.lock.SpinLock;
-import org.wildfly.common.lock.Locks;
 
 /**
  * EQE base class: tail section.
@@ -59,11 +56,6 @@ abstract class EnhancedQueueExecutorBase1 extends EnhancedQueueExecutorBase0 {
      * moderate contention among 8 CPUs can result in thousands of spin misses per execution.
      */
     static final boolean TAIL_LOCK = COMBINED_LOCK || readBooleanPropertyPrefixed("tail-lock", true);
-
-    /**
-     * The tail lock.  Only used if {@link #TAIL_LOCK} is {@code true}.
-     */
-    final ExtendedLock tailLock = TAIL_LOCK ? TAIL_SPIN ? new SpinLock() : Locks.reentrantLock() : null;
 
     // =======================================================
     // Current state fields

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase3.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase3.java
@@ -21,9 +21,6 @@ package org.jboss.threads;
 import static org.jboss.threads.JBossExecutors.unsafe;
 
 import org.wildfly.common.annotation.NotNull;
-import org.wildfly.common.lock.ExtendedLock;
-import org.wildfly.common.lock.SpinLock;
-import org.wildfly.common.lock.Locks;
 
 /**
  * EQE base class: head section.
@@ -51,10 +48,6 @@ abstract class EnhancedQueueExecutorBase3 extends EnhancedQueueExecutorBase2 {
      * Use a spin lock for the head lock.
      */
     static final boolean HEAD_SPIN = readBooleanPropertyPrefixed("head-spin", true);
-    /**
-     * The head lock.  Only used if {@link #HEAD_LOCK} is {@code true}.
-     */
-    final ExtendedLock headLock = COMBINED_LOCK ? tailLock : HEAD_LOCK ? HEAD_SPIN ? new SpinLock() : Locks.reentrantLock() : null;
 
     // =======================================================
     // Current state fields


### PR DESCRIPTION
Previously the headLock and tailLock were accessed across
padding fields causing cache misses and regressed performance
compared to execution with locks disabled.