### PR TITLE
Implement synchronized lock mode

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase1.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase1.java
@@ -52,6 +52,11 @@ abstract class EnhancedQueueExecutorBase1 extends EnhancedQueueExecutorBase0 {
     static final boolean TAIL_SPIN = ! COMBINED_LOCK && readBooleanPropertyPrefixed("tail-spin", false);
 
     /**
+     * Use synchronized for the tail lock.
+     */
+    static final boolean TAIL_SYNCHRONIZED = readBooleanPropertyPrefixed("tail-synchronized", false);
+
+    /**
      * Attempt to lock frequently-contended operations on the list tail.  This defaults to {@code true} because
      * moderate contention among 8 CPUs can result in thousands of spin misses per execution.
      */

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase3.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutorBase3.java
@@ -48,6 +48,10 @@ abstract class EnhancedQueueExecutorBase3 extends EnhancedQueueExecutorBase2 {
      * Use a spin lock for the head lock.
      */
     static final boolean HEAD_SPIN = readBooleanPropertyPrefixed("head-spin", true);
+    /**
+     * Use synchronized for the head lock.
+     */
+    static final boolean HEAD_SYNCHRONIZED = readBooleanPropertyPrefixed("head-synchronized", false);
 
     // =======================================================
     // Current state fields


### PR DESCRIPTION
This change adds two new properties:
`jboss.threads.eqe.head-synchronized` and
`jboss.threads.eqe.tail-synchronized` which both default to `false`. The
default configuration is not modified.

Benchmark results for 32 threads submitting tasks to a pool with 100
threads on a 14 core system with SMT:
```
Benchmark                           (cores)             (factory)   Mode  Cnt        Score       Error  Units
ExecutorBenchmarks.benchmarkSubmit       28  THREAD_POOL_EXECUTOR  thrpt    4   783474.478 ± 15490.365  ops/s
ExecutorBenchmarks.benchmarkSubmit       28          EQE_NO_LOCKS  thrpt    4  1809063.938 ± 13020.180  ops/s
ExecutorBenchmarks.benchmarkSubmit       28         EQE_SPIN_LOCK  thrpt    4   349376.970 ±  6046.860  ops/s
ExecutorBenchmarks.benchmarkSubmit       28      EQE_SYNCHRONIZED  thrpt    4   530502.587 ± 14570.999  ops/s
ExecutorBenchmarks.benchmarkSubmit       28    EQE_REENTRANT_LOCK  thrpt    4   346651.156 ±  4326.834  ops/s
```

32 threads submitting tasks to fixed executors with 16 threads, given 28
logical cores:
```
Benchmark                           (cores)             (factory)   Mode  Cnt       Score       Error  Units
ExecutorBenchmarks.benchmarkSubmit       28  THREAD_POOL_EXECUTOR  thrpt    4  825319.589 ±  4505.611  ops/s
ExecutorBenchmarks.benchmarkSubmit       28          EQE_NO_LOCKS  thrpt    4  557950.673 ± 17938.335  ops/s
ExecutorBenchmarks.benchmarkSubmit       28         EQE_SPIN_LOCK  thrpt    4  348318.297 ± 10356.888  ops/s
ExecutorBenchmarks.benchmarkSubmit       28      EQE_SYNCHRONIZED  thrpt    4  534380.322 ± 11343.607  ops/s
ExecutorBenchmarks.benchmarkSubmit       28    EQE_REENTRANT_LOCK  thrpt    4  349117.764 ±  7952.673  ops/s
```

28 threads submitting tasks to fixed executors with 14 threads on 4
logical cores:
```
Benchmark                           (cores)             (factory)   Mode  Cnt       Score       Error  Units
ExecutorBenchmarks.benchmarkSubmit        4  THREAD_POOL_EXECUTOR  thrpt    4  442214.809 ± 26262.597  ops/s
ExecutorBenchmarks.benchmarkSubmit        4          EQE_NO_LOCKS  thrpt    4   58356.917 ±  5531.586  ops/s
ExecutorBenchmarks.benchmarkSubmit        4         EQE_SPIN_LOCK  thrpt    4  586386.965 ± 48919.536  ops/s
ExecutorBenchmarks.benchmarkSubmit        4      EQE_SYNCHRONIZED  thrpt    4  580648.561 ± 45254.171  ops/s
ExecutorBenchmarks.benchmarkSubmit        4    EQE_REENTRANT_LOCK  thrpt    4  362551.035 ± 20957.368  ops/s
```

28 threads submitting tasks to fixed executors with 14 threads on 2
logical cores:
```
Benchmark                           (cores)             (factory)   Mode  Cnt       Score        Error  Units
ExecutorBenchmarks.benchmarkSubmit        2  THREAD_POOL_EXECUTOR  thrpt    4  351998.453 ±  16577.701  ops/s
ExecutorBenchmarks.benchmarkSubmit        2          EQE_NO_LOCKS  thrpt    4  132630.643 ±   2417.655  ops/s
ExecutorBenchmarks.benchmarkSubmit        2         EQE_SPIN_LOCK  thrpt    4  334101.489 ± 115874.965  ops/s
ExecutorBenchmarks.benchmarkSubmit        2      EQE_SYNCHRONIZED  thrpt    4  389043.173 ±  24526.249  ops/s
ExecutorBenchmarks.benchmarkSubmit        2    EQE_REENTRANT_LOCK  thrpt    4  332865.539 ±  82805.557  ops/s
```