### PR TITLE
JBTHR-82: Add padding to PoolThreadNode

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -2134,7 +2134,21 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         }
     }
 
-    static final class PoolThreadNode extends QNode {
+    /** Padding between PoolThreadNode task and parked fields and QNode.next */
+    static abstract class PoolThreadNodeBase extends QNode {
+        /**
+         * Padding fields.
+         */
+        @SuppressWarnings("unused")
+        int p00, p01, p02, p03,
+            p04, p05, p06, p07,
+            p08, p09, p0A, p0B,
+            p0C, p0D, p0E, p0F;
+
+        PoolThreadNodeBase() {}
+    }
+
+    static final class PoolThreadNode extends PoolThreadNodeBase {
 
         /**
          * Thread is running normally.


### PR DESCRIPTION
Prevent false sharing between the next QNode reference and
task/parked references.

Note that I have not verified this on other hardware yet.

Benchmarks including #61 and #62:

```
Benchmark                           (cores)  (executorThreads)             (factory)   Mode  Cnt        Score         Error  Units
ExecutorBenchmarks.benchmarkSubmit        1              16,16  THREAD_POOL_EXECUTOR  thrpt    4   326116.492 ±  146036.293  ops/s
ExecutorBenchmarks.benchmarkSubmit        1              16,16          EQE_NO_LOCKS  thrpt    4    65914.109 ±    1464.288  ops/s
ExecutorBenchmarks.benchmarkSubmit        1              16,16    EQE_REENTRANT_LOCK  thrpt    4   357265.848 ±    4071.403  ops/s
ExecutorBenchmarks.benchmarkSubmit        1              16,16         EQE_SPIN_LOCK  thrpt    4   361602.468 ±    3444.304  ops/s
ExecutorBenchmarks.benchmarkSubmit        1              16,16      EQE_SYNCHRONIZED  thrpt    4   359631.937 ±    5397.668  ops/s
ExecutorBenchmarks.benchmarkSubmit        1            100,200  THREAD_POOL_EXECUTOR  thrpt    4   308487.103 ±    5801.382  ops/s
ExecutorBenchmarks.benchmarkSubmit        1            100,200          EQE_NO_LOCKS  thrpt    4   176609.314 ±   30232.943  ops/s
ExecutorBenchmarks.benchmarkSubmit        1            100,200    EQE_REENTRANT_LOCK  thrpt    4   175486.358 ±   59950.217  ops/s
ExecutorBenchmarks.benchmarkSubmit        1            100,200         EQE_SPIN_LOCK  thrpt    4   165490.845 ±   49763.981  ops/s
ExecutorBenchmarks.benchmarkSubmit        1            100,200      EQE_SYNCHRONIZED  thrpt    4   179943.869 ±   22819.618  ops/s
ExecutorBenchmarks.benchmarkSubmit        2              16,16  THREAD_POOL_EXECUTOR  thrpt    4   368767.974 ±   38522.178  ops/s
ExecutorBenchmarks.benchmarkSubmit        2              16,16          EQE_NO_LOCKS  thrpt    4    55472.457 ±    1925.803  ops/s
ExecutorBenchmarks.benchmarkSubmit        2              16,16    EQE_REENTRANT_LOCK  thrpt    4   256884.761 ±   29609.225  ops/s
ExecutorBenchmarks.benchmarkSubmit        2              16,16         EQE_SPIN_LOCK  thrpt    4   255816.388 ±   24177.879  ops/s
ExecutorBenchmarks.benchmarkSubmit        2              16,16      EQE_SYNCHRONIZED  thrpt    4   241893.734 ±    6079.631  ops/s
ExecutorBenchmarks.benchmarkSubmit        2            100,200  THREAD_POOL_EXECUTOR  thrpt    4   344169.878 ±   11059.312  ops/s
ExecutorBenchmarks.benchmarkSubmit        2            100,200          EQE_NO_LOCKS  thrpt    4   245903.740 ±   33144.509  ops/s
ExecutorBenchmarks.benchmarkSubmit        2            100,200    EQE_REENTRANT_LOCK  thrpt    4   245197.665 ±    6465.032  ops/s
ExecutorBenchmarks.benchmarkSubmit        2            100,200         EQE_SPIN_LOCK  thrpt    4   163399.253 ±  207794.254  ops/s
ExecutorBenchmarks.benchmarkSubmit        2            100,200      EQE_SYNCHRONIZED  thrpt    4   246003.754 ±   22858.193  ops/s
ExecutorBenchmarks.benchmarkSubmit        4              16,16  THREAD_POOL_EXECUTOR  thrpt    4   450494.059 ±   29953.682  ops/s
ExecutorBenchmarks.benchmarkSubmit        4              16,16          EQE_NO_LOCKS  thrpt    4   158434.916 ±   10192.862  ops/s
ExecutorBenchmarks.benchmarkSubmit        4              16,16    EQE_REENTRANT_LOCK  thrpt    4   494875.281 ±    6545.577  ops/s
ExecutorBenchmarks.benchmarkSubmit        4              16,16         EQE_SPIN_LOCK  thrpt    4   466354.539 ±   14515.204  ops/s
ExecutorBenchmarks.benchmarkSubmit        4              16,16      EQE_SYNCHRONIZED  thrpt    4   463023.888 ±   54858.197  ops/s
ExecutorBenchmarks.benchmarkSubmit        4            100,200  THREAD_POOL_EXECUTOR  thrpt    4   451589.559 ±    5239.375  ops/s
ExecutorBenchmarks.benchmarkSubmit        4            100,200          EQE_NO_LOCKS  thrpt    4   463642.750 ±    8429.229  ops/s
ExecutorBenchmarks.benchmarkSubmit        4            100,200    EQE_REENTRANT_LOCK  thrpt    4   427951.575 ±    8824.821  ops/s
ExecutorBenchmarks.benchmarkSubmit        4            100,200         EQE_SPIN_LOCK  thrpt    4   185269.395 ±   68590.794  ops/s
ExecutorBenchmarks.benchmarkSubmit        4            100,200      EQE_SYNCHRONIZED  thrpt    4   447494.476 ±   54761.052  ops/s
ExecutorBenchmarks.benchmarkSubmit        8              16,16  THREAD_POOL_EXECUTOR  thrpt    4   473264.007 ±   11061.242  ops/s
ExecutorBenchmarks.benchmarkSubmit        8              16,16          EQE_NO_LOCKS  thrpt    4   258292.654 ±    6618.646  ops/s
ExecutorBenchmarks.benchmarkSubmit        8              16,16    EQE_REENTRANT_LOCK  thrpt    4   639305.849 ±   26319.268  ops/s
ExecutorBenchmarks.benchmarkSubmit        8              16,16         EQE_SPIN_LOCK  thrpt    4   642832.340 ±   21311.807  ops/s
ExecutorBenchmarks.benchmarkSubmit        8              16,16      EQE_SYNCHRONIZED  thrpt    3   912348.107 ±  106252.377  ops/s
ExecutorBenchmarks.benchmarkSubmit        8            100,200  THREAD_POOL_EXECUTOR  thrpt    4   479414.510 ±   24472.126  ops/s
ExecutorBenchmarks.benchmarkSubmit        8            100,200          EQE_NO_LOCKS  thrpt    4   905594.687 ±   11419.150  ops/s
ExecutorBenchmarks.benchmarkSubmit        8            100,200    EQE_REENTRANT_LOCK  thrpt    4   645462.681 ±   33541.558  ops/s
ExecutorBenchmarks.benchmarkSubmit        8            100,200         EQE_SPIN_LOCK  thrpt    4   473331.654 ±  512107.241  ops/s
ExecutorBenchmarks.benchmarkSubmit        8            100,200      EQE_SYNCHRONIZED  thrpt    4   742494.186 ±   73372.518  ops/s
ExecutorBenchmarks.benchmarkSubmit       14              16,16  THREAD_POOL_EXECUTOR  thrpt    4   800962.255 ±   59932.534  ops/s
ExecutorBenchmarks.benchmarkSubmit       14              16,16          EQE_NO_LOCKS  thrpt    4   749956.757 ± 1100067.624  ops/s
ExecutorBenchmarks.benchmarkSubmit       14              16,16    EQE_REENTRANT_LOCK  thrpt    4   723888.128 ±   18899.659  ops/s
ExecutorBenchmarks.benchmarkSubmit       14              16,16         EQE_SPIN_LOCK  thrpt    4   760860.695 ±    2952.460  ops/s
ExecutorBenchmarks.benchmarkSubmit       14              16,16      EQE_SYNCHRONIZED  thrpt    4  1145527.979 ±   13244.276  ops/s
ExecutorBenchmarks.benchmarkSubmit       14            100,200  THREAD_POOL_EXECUTOR  thrpt    4   764837.118 ±   53519.326  ops/s
ExecutorBenchmarks.benchmarkSubmit       14            100,200          EQE_NO_LOCKS  thrpt    4  1508706.609 ±   94346.465  ops/s
ExecutorBenchmarks.benchmarkSubmit       14            100,200    EQE_REENTRANT_LOCK  thrpt    4   724841.310 ±   46840.635  ops/s
ExecutorBenchmarks.benchmarkSubmit       14            100,200         EQE_SPIN_LOCK  thrpt    4   765385.846 ±   17031.895  ops/s
ExecutorBenchmarks.benchmarkSubmit       14            100,200      EQE_SYNCHRONIZED  thrpt    3  1130725.073 ±   36681.898  ops/s
ExecutorBenchmarks.benchmarkSubmit       28              16,16  THREAD_POOL_EXECUTOR  thrpt    4   818842.995 ±  174954.784  ops/s
ExecutorBenchmarks.benchmarkSubmit       28              16,16          EQE_NO_LOCKS  thrpt    4  1913216.509 ±  404872.852  ops/s
ExecutorBenchmarks.benchmarkSubmit       28              16,16    EQE_REENTRANT_LOCK  thrpt    4   681346.537 ±    6138.795  ops/s
ExecutorBenchmarks.benchmarkSubmit       28              16,16         EQE_SPIN_LOCK  thrpt    4   677400.226 ±   20658.545  ops/s
ExecutorBenchmarks.benchmarkSubmit       28              16,16      EQE_SYNCHRONIZED  thrpt    4  1135476.452 ±   28945.514  ops/s
ExecutorBenchmarks.benchmarkSubmit       28            100,200  THREAD_POOL_EXECUTOR  thrpt    4   776200.791 ±  202359.833  ops/s
ExecutorBenchmarks.benchmarkSubmit       28            100,200          EQE_NO_LOCKS  thrpt    4  2059516.364 ±   62077.064  ops/s
ExecutorBenchmarks.benchmarkSubmit       28            100,200    EQE_REENTRANT_LOCK  thrpt    4   675827.048 ±   47633.751  ops/s
ExecutorBenchmarks.benchmarkSubmit       28            100,200         EQE_SPIN_LOCK  thrpt    4   686109.665 ±   28971.859  ops/s
ExecutorBenchmarks.benchmarkSubmit       28            100,200      EQE_SYNCHRONIZED  thrpt    4  1122769.996 ±   25395.709  ops/s
```