### PR TITLE
JBTHR-83: unpark is never invoked under a lock

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1717,12 +1717,12 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
     private int tryExecute(final Runnable runnable) {
         QNode tailNext;
         PoolThreadNode toUnpark = null;
-        TaskNode tail = this.tail;
         final int result;
         TaskNode node = null;
         ExtendedLock tailLock = this.tailLock;
         if (TAIL_LOCK) tailLock.lock();
         try {
+            TaskNode tail = this.tail;
             for (; ; ) {
                 tailNext = tail.getNext();
                 if (tailNext instanceof TaskNode) {

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1774,9 +1774,9 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                         }
                         // otherwise the consumer gave up or was exited already, so fall out and...
                     }
+                    if (UPDATE_STATISTICS) spinMisses.increment();
                     // retry with new tail(snapshot) as was foretold
                     tail = this.tail;
-                    if (UPDATE_STATISTICS) spinMisses.increment();
                 } else if (tailNext == null) {
                     // no consumers available; maybe we can start one
                     int tr = tryAllocateThread(growthResistance);


### PR DESCRIPTION
Unpark is an expensive operation, taking many times locker than
other operations run with the exclusive tail lock. This change
moves unpark outside of the locked region to allow work to
continue.