### PR TITLE
Update the optimistic park spin to use a deterministic approach

### DIFF
--- a/src/main/java/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java/org/jboss/threads/JDKSpecific.java
@@ -40,4 +40,8 @@ final class JDKSpecific {
             default: throw Assert.impossibleSwitchCase(timeUnit);
         }
     }
+
+    static void onSpinWait() {
+        // no operation
+    }
 }

--- a/src/main/java9/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java9/org/jboss/threads/JDKSpecific.java
@@ -28,4 +28,8 @@ final class JDKSpecific {
     static TemporalUnit timeToTemporal(final TimeUnit timeUnit) {
         return timeUnit.toChronoUnit();
     }
+
+    static void onSpinWait() {
+        Thread.onSpinWait();
+    }
 }


### PR DESCRIPTION
This algorithm first spins, escalates to yield, then parks after
a fixed number of iterations. This change updates the edge conditions
to avoid cases where we yield without attempting cas operation
afterward.