### PR TITLE
Add a property to maintain `activeCount` without recording all statistics

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -137,6 +137,11 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
      */
     static final boolean UPDATE_STATISTICS = readBooleanPropertyPrefixed("statistics", false);
     /**
+     * Maintain an estimate of the number of threads which are currently doing work on behalf of the thread pool.
+     */
+    static final boolean UPDATE_ACTIVE_COUNT =
+            UPDATE_STATISTICS || readBooleanPropertyPrefixed("statistics.active-count", false);
+    /**
      * Suppress queue limit and size tracking for performance.
      */
     static final boolean NO_QUEUE_LIMIT = readBooleanPropertyPrefixed("unlimited-queue", false);
@@ -1544,11 +1549,13 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                 } else {
                     Thread.interrupted();
                 }
-                if (UPDATE_STATISTICS) incrementActiveCount();
+                if (UPDATE_ACTIVE_COUNT) incrementActiveCount();
                 safeRun(task);
-                if (UPDATE_STATISTICS) {
+                if (UPDATE_ACTIVE_COUNT) {
                     decrementActiveCount();
-                    completedTaskCounter.increment();
+                    if (UPDATE_STATISTICS) {
+                        completedTaskCounter.increment();
+                    }
                 }
             }
         }


### PR DESCRIPTION
This adds a `jboss.threads.eqe.statistics.active-count` property
which can be set to `true` to update `activeCount` without also
updating other statistics.