### PR TITLE
Eagerly create and reuse PoolThreadNode instances

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1517,7 +1517,6 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         private QNode getOrAddNode(PoolThreadNode nextPoolThreadNode) {
             TaskNode head;
             QNode headNext;
-            int spins = PARK_SPINS;
             for (;;) {
                 head = EnhancedQueueExecutor.this.head;
                 headNext = head.getNext();
@@ -1527,14 +1526,6 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                         if (! NO_QUEUE_LIMIT) decreaseQueueSize();
                         return taskNode;
                     }
-                } else if (headNext == null && spins > 0) {
-                    // active wait for a few moments, but don't count as a spin miss
-                    if (spins-- <= YIELD_FACTOR) {
-                        Thread.yield();
-                    } else {
-                        JDKSpecific.onSpinWait();
-                    }
-                    continue;
                 } else if (headNext instanceof PoolThreadNode || headNext == null) {
                     nextPoolThreadNode.setNextRelaxed(headNext);
                     if (head.compareAndSetNext(headNext, nextPoolThreadNode)) {

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1432,10 +1432,9 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                     // task node was removed
                     doRunTask(((TaskNode) node).getAndClearTask());
                     continue;
-                } else if (node instanceof PoolThreadNode) {
+                } else if (node == nextPoolThreadNode) {
                     // pool thread node was added
-                    final PoolThreadNode newNode = (PoolThreadNode) node;
-                    assert newNode == nextPoolThreadNode;
+                    final PoolThreadNode newNode = nextPoolThreadNode;
                     // nextPoolThreadNode has been added to the queue, a new node is required for next time.
                     nextPoolThreadNode = new PoolThreadNode(currentThread);
                     // at this point, we are registered into the queue


### PR DESCRIPTION
When getOrAddNode does not submit a PoolThreadNode it's not necessary
to create more instances.