### PR TITLE
Fix faulty assertion

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1733,7 +1733,7 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                 // post-actions (fail):
                 //   retry with new tail(snapshot)
                 if (tail.compareAndSetNext(tailNext, tailNextNext)) {
-                    assert tail instanceof TaskNode && tail.task == null;
+                    assert tail instanceof TaskNode;
                     PoolThreadNode consumerNode = (PoolThreadNode) tailNext;
                     // state change ex2:
                     //   tail(snapshot).next(snapshot).task ← runnable


### PR DESCRIPTION
The assertion is invalid because if there are two worker threads, and one worker has updated the head pointer to a populated task node, while in the meantime the second thread observes the end of the list and adds a pooled thread node to the end, then tryExecute may observe a 'dead' task node which nevertheless still contains a task.