### PR TITLE
TaskNode.task is non-volatile

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -2242,7 +2242,7 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
     }
 
     static final class TaskNode extends QNode {
-        volatile Runnable task;
+        Runnable task;
 
         TaskNode(final Runnable task) {
             // we always start task nodes with a {@code null} next


### PR DESCRIPTION
The task value is only set to a non-null value by the constructor
when nodes are created. This indicates a clear happens-before
relationship with consumers reading the task value, which first
remove the TaskNode from the queue. Setting the task value to null
prevents memory leaks but is not required to update other consumers.
The two types of consumers are:
1. ThreadBody.getOrAddNode: Removes a TaskNode from the queue, then
   ThreadBody.run executes the result of getAndClearTask.
2. EQE.shutdownNow: Removes TaskNodes from the queue, then reads
   TaskNode.task. Only one consumer can successfully remove a node
   from the queue so there is no race between shutdownNow reading
   task values and ThreadBody.run invoking getAndClearTask to null
   the value.