### PR TITLE
Simplify TaskNode.getAndClearTask

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -2250,11 +2250,9 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         }
 
         Runnable getAndClearTask() {
-            try {
-                return task;
-            } finally {
-                this.task = null;
-            }
+            Runnable result = task;
+            task = null;
+            return result;
         }
     }
 


### PR DESCRIPTION
No need to try/finally. Both paths likely optimize to the same
result, this approach results in less bytecode to help the JIT.

Before:
```
Runnable getAndClearTask()
     0: aload_0
     1: getfield        #2   // Field task:Ljava/lang/Runnable;
     4: astore_1
     5: aload_0
     6: aconst_null
     7: putfield        #2   // Field task:Ljava/lang/Runnable;
    10: aload_1
    11: areturn
    12: astore_2
    13: aload_0
    14: aconst_null
    15: putfield        #2   // Field task:Ljava/lang/Runnable;
    18: aload_2
    19: athrow
```

After:
```
Runnable getAndClearTask()
     0: aload_0
     1: getfield        #2   // Field task:Ljava/lang/Runnable;
     4: astore_1
     5: aload_0
     6: aconst_null
     7: putfield        #2   // Field task:Ljava/lang/Runnable;
    10: aload_1
    11: areturn
```