### PR TITLE
Remove onSpinMisses when failed due to stale view of world

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -1724,8 +1724,6 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
             tailNext = tail.getNext();
             // tail is already consumed
             if (tailNext == tail) {
-                if (UPDATE_STATISTICS) spinMisses.increment();
-                JDKSpecific.onSpinWait();
                 // retry with new tail(snapshot)
                 tail = this.tail;
                 continue;
@@ -1736,8 +1734,6 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
                 // Opportunistically update tail to the next node. If this operation has been handled by
                 // another thread we fall back to the loop and try again instead of duplicating effort.
                 if (!compareAndSetTail(tail, tailNextTaskNode)) {
-                    if (UPDATE_STATISTICS) spinMisses.increment();
-                    JDKSpecific.onSpinWait();
                     tail = this.tail;
                     continue;
                 }


### PR DESCRIPTION
In both cases awaiting (in the form of `onSpinMisses`) while catching up with the state of the world isn't a good idea. Probably it coud alleviate a bit the contention under load, improving artificially troughput. but it can harm max latencies. 

A good proof of this is on https://github.com/AdoptOpenJDK/openjdk-jdk14/blob/f7165c322a6abefa34afa9eeb76dbd56f70aae09/src/java.base/share/classes/java/util/concurrent/ConcurrentLinkedQueue.java#L369 (the base algorithm is very similar, based on the Michael-Scott queue): on a failed CAS due to contention or a stale view of the world, it retries immediately despite the presence of `onSpinWait` on the jdk 14 release.