### PR TITLE
Implement CachedExecutorView to split underlying cached pools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.16.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <version>2.1.14.Final</version>

--- a/src/main/java/org/jboss/threads/QueuedViewExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuedViewExecutor.java
@@ -1,0 +1,288 @@
+package org.jboss.threads;
+
+import org.jboss.logging.Logger;
+import org.wildfly.common.Assert;
+import org.wildfly.common.lock.ExtendedLock;
+import org.wildfly.common.lock.Locks;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+
+/**
+ * An executor service that is actually a "view" over another executor service.
+ */
+final class QueuedViewExecutor extends ViewExecutor {
+    private static final Logger log = Logger.getLogger("org.jboss.threads.view-executor");
+    private static final Runnable[] NO_RUNNABLES = new Runnable[0];
+
+    private final Executor delegate;
+
+    private final ExtendedLock lock;
+    private final Condition shutDownCondition;
+    private final ArrayDeque<Runnable> queue;
+    private final Set<TaskWrapper> allWrappers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final int queueLimit;
+    private final short maxCount;
+    private short submittedCount;
+    private short runningCount;
+    private int state = ST_RUNNING;
+
+    private static final int ST_RUNNING = 0;
+    private static final int ST_SHUTDOWN_REQ = 1;
+    private static final int ST_SHUTDOWN_INT_REQ = 2;
+    private static final int ST_STOPPED = 3;
+
+    QueuedViewExecutor(
+            final Executor delegate,
+            final short maxCount,
+            final int queueLimit,
+            final int queueInitialSize,
+            final Thread.UncaughtExceptionHandler handler) {
+        this.delegate = delegate;
+        this.maxCount = maxCount;
+        this.queueLimit = queueLimit;
+        this.setExceptionHandler(handler);
+        queue = new ArrayDeque<>(Math.min(queueLimit, queueInitialSize));
+        lock = Locks.reentrantLock();
+        shutDownCondition = lock.newCondition();
+    }
+
+    public void execute(final Runnable command) {
+        lock.lock();
+        try {
+            if (state != ST_RUNNING) {
+                throw new RejectedExecutionException("Executor has been shut down");
+            }
+            final short submittedCount = this.submittedCount;
+            if (runningCount + submittedCount < maxCount) {
+                this.submittedCount = (short) (submittedCount + 1);
+                final TaskWrapper tw = new TaskWrapper(JBossExecutors.classLoaderPreservingTask(command));
+                allWrappers.add(tw);
+                try {
+                    /* this cannot be easily moved outside of the lock, otherwise queued tasks might never run
+                     * under certain rare scenarios.
+                     */
+                    delegate.execute(tw);
+                } catch (Throwable t) {
+                    this.submittedCount--;
+                    allWrappers.remove(tw);
+                    throw t;
+                }
+            } else if (queue.size() < queueLimit) {
+                queue.add(command);
+            } else {
+                throw new RejectedExecutionException("No executor queue space remaining");
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void shutdown(boolean interrupt) {
+        lock.lock();
+        int oldState = this.state;
+        if (oldState < ST_SHUTDOWN_REQ) {
+            // do shutdown
+            final boolean emptyQueue;
+            try {
+                emptyQueue = queue.isEmpty();
+            } catch (Throwable t) {
+                lock.unlock();
+                throw t;
+            }
+            if (runningCount == 0 && submittedCount == 0 && emptyQueue) {
+                this.state = ST_STOPPED;
+                try {
+                    shutDownCondition.signalAll();
+                } finally {
+                    lock.unlock();
+                }
+                runTermination();
+                return;
+            }
+        }
+        // didn't exit
+        this.state = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
+        lock.unlock();
+        if (interrupt && oldState < ST_SHUTDOWN_INT_REQ) {
+            // interrupt all runners
+            for (TaskWrapper wrapper : allWrappers) {
+                wrapper.interrupt();
+            }
+        }
+    }
+
+    public List<Runnable> shutdownNow() {
+        lock.lock();
+        int oldState = this.state;
+        final Runnable[] tasks;
+        try {
+            tasks = queue.toArray(NO_RUNNABLES);
+            queue.clear();
+        } catch (Throwable t) {
+            lock.unlock();
+            throw t;
+        }
+        if (oldState < ST_SHUTDOWN_INT_REQ) {
+            // do shutdown
+            if (runningCount == 0 && submittedCount == 0) {
+                this.state = ST_STOPPED;
+                try {
+                    shutDownCondition.signalAll();
+                } finally {
+                    lock.unlock();
+                }
+                runTermination();
+            } else {
+                lock.unlock();
+                this.state = ST_SHUTDOWN_INT_REQ;
+                // interrupt all runners
+                for (TaskWrapper wrapper : allWrappers) {
+                    wrapper.interrupt();
+                }
+            }
+        } else {
+            lock.unlock();
+        }
+        return Arrays.asList(tasks);
+    }
+
+    public boolean isShutdown() {
+        lock.lock();
+        try {
+            return state >= ST_SHUTDOWN_REQ;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean isTerminated() {
+        lock.lock();
+        try {
+            return state == ST_STOPPED;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        lock.lock();
+        try {
+            if (state == ST_STOPPED) {
+                return true;
+            }
+            final long nanos = unit.toNanos(timeout);
+            if (nanos <= 0) {
+                return false;
+            }
+            long elapsed = 0;
+            final long start = System.nanoTime();
+            for (;;) {
+                shutDownCondition.awaitNanos(nanos - elapsed);
+                if (state == ST_STOPPED) {
+                    return true;
+                }
+                elapsed = System.nanoTime() - start;
+                if (elapsed >= nanos) {
+                    return false;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public String toString() {
+        return "view of " + delegate;
+    }
+
+    class TaskWrapper implements Runnable {
+        private volatile Thread thread;
+        private Runnable command;
+
+        TaskWrapper(final Runnable command) {
+            this.command = command;
+        }
+
+        void interrupt() {
+            final Thread thread = this.thread;
+            if (thread != null) {
+                thread.interrupt();
+            }
+        }
+
+        public void run() {
+            boolean removeFromAllWrappersAfterCompletion = true;
+            thread = Thread.currentThread();
+            try {
+                for (;;) {
+                    lock.lock();
+                    try {
+                        submittedCount--;
+                        runningCount++;
+                    } finally {
+                        lock.unlock();
+                    }
+                    try {
+                        command.run();
+                    } catch (Throwable t) {
+                        try {
+                            getExceptionHandler().uncaughtException(Thread.currentThread(), t);
+                        } catch (Throwable ignored) {
+                        }
+                    }
+                    lock.lock();
+                    runningCount--;
+                    try {
+                        command = queue.pollFirst();
+                    } catch (Throwable t) {
+                        lock.unlock();
+                        throw t;
+                    }
+                    if (runningCount + submittedCount < maxCount && command != null) {
+                        // execute next
+                        submittedCount++;
+                        lock.unlock();
+                    } else if (command == null && runningCount == 0 && submittedCount == 0 && state != ST_RUNNING) {
+                        // we're the last task
+                        state = ST_STOPPED;
+                        try {
+                            shutDownCondition.signalAll();
+                        } finally {
+                            lock.unlock();
+                        }
+                        runTermination();
+                        return;
+                    } else {
+                        lock.unlock();
+                        return;
+                    }
+                    try {
+                        delegate.execute(this);
+                        removeFromAllWrappersAfterCompletion = false;
+                        // resubmitted this task for execution, so return
+                        return;
+                    } catch (Throwable t) {
+                        log.warn("Failed to resubmit executor task to delegate executor"
+                            + " (executing task immediately instead)", t);
+                        // resubmit failed, so continue execution in this thread
+                    }
+                }
+            } finally {
+                if (removeFromAllWrappersAfterCompletion) {
+                    allWrappers.remove(this);
+                }
+                thread = null;
+            }
+        }
+    }
+}

--- a/src/main/java/org/jboss/threads/QueuelessViewExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuelessViewExecutor.java
@@ -1,0 +1,277 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.threads;
+
+import static org.jboss.threads.JBossExecutors.unsafe;
+
+import org.wildfly.common.Assert;
+import org.wildfly.common.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A View Executor implementation which avoids lock contention in the common path. This allows us to
+ * provide references to the same underlying pool of threads to different consumers and utilize distinct
+ * instrumentation without duplicating resources. This implementation is optimized to avoid locking
+ * in cases where the view is not required queue work beyond a fixed number of permits, useful for
+ * cached executors for example.
+ *
+ * @author <a href="mailto:ckozak@ckozak.net">Carter Kozak</a>
+ */
+final class QueuelessViewExecutor extends ViewExecutor {
+    private static final long stateOffset;
+    static {
+        try {
+            stateOffset = unsafe.objectFieldOffset(QueuelessViewExecutor.class.getDeclaredField("state"));
+        } catch (NoSuchFieldException e) {
+            throw new NoSuchFieldError(e.getMessage());
+        }
+    }
+
+    private static final int SHUTDOWN_MASK = 1 << 31;
+    private static final int ACTIVE_COUNT_MASK = (1 << 31) - 1;
+
+    private final Executor delegate;
+    private final int maxCount;
+
+    private final Object shutdownLock = new Object();
+    private final Set<QueuelessViewExecutorRunnable> activeRunnables = ConcurrentHashMap.newKeySet();
+
+    /**
+     * State structure.
+     *
+     * <ul>
+     *   <li>Bit 00..30: Number of active tasks (unsigned)
+     *   <li>Bit 31: executor shutdown state; 0 = shutdown has not been requested
+     * </ul>
+     */
+    @SuppressWarnings("unused")
+    private volatile int state = 0;
+    private volatile boolean interrupted = false;
+
+    QueuelessViewExecutor(
+            final Executor delegate,
+            final int maxCount,
+            @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+        this.delegate = Assert.checkNotNullParam("delegate", delegate);
+        this.maxCount = maxCount;
+        this.setExceptionHandler(uncaughtExceptionHandler);
+    }
+
+    @Override
+    public void shutdown(boolean interrupt) {
+        for (;;) {
+            int stateSnapshot = state;
+            if (isShutdown(stateSnapshot)) {
+                break; // nothing to do
+            }
+            int newState = stateSnapshot | SHUTDOWN_MASK;
+            if (compareAndSwapState(stateSnapshot, newState)) {
+                notifyWaitersIfTerminated(newState);
+                break;
+            }
+        }
+        if (interrupt) {
+            interrupted = true;
+            activeRunnables.forEach(QueuelessViewExecutorRunnable::interrupt);
+        }
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown(true);
+        // This implementation is built for cached executors which do not queue so it's impossible
+        // to have queued runnables.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isShutdown(state);
+    }
+
+    private static boolean isShutdown(int state) {
+        return (state & SHUTDOWN_MASK) != 0;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isTerminated(state);
+    }
+
+    private static boolean isTerminated(int state) {
+        return state == SHUTDOWN_MASK;
+    }
+
+    private void notifyWaitersIfTerminated(int stateSnapshot) {
+        if (isTerminated(stateSnapshot)) {
+            synchronized (shutdownLock) {
+                shutdownLock.notifyAll();
+            }
+            runTermination();
+        }
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        long remainingNanos = unit.toNanos(timeout);
+        // Use the system precise clock to avoid issues resulting from time changes.
+        long now = System.nanoTime();
+        synchronized (shutdownLock) {
+            while (!isTerminated()) {
+                remainingNanos -= Math.max(-now + (now = System.nanoTime()), 0L);
+                long remainingMillis = TimeUnit.MILLISECONDS.convert(remainingNanos, TimeUnit.NANOSECONDS);
+                if (remainingMillis <= 0) {
+                    return false;
+                }
+                shutdownLock.wait(remainingMillis);
+            }
+            return true;
+        }
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        Assert.checkNotNullParam("task", task);
+        incrementActiveOrReject();
+        boolean submittedTask = false;
+        try {
+            // When CachedExecutorViewRunnable allocation fails the active count must be reduced.
+            delegate.execute(new QueuelessViewExecutorRunnable(task));
+            submittedTask = true;
+        } finally {
+            if (!submittedTask) decrementActive();
+        }
+    }
+
+    /** Increments the active task count, otherwise throws a {@link RejectedExecutionException}. */
+    private void incrementActiveOrReject() {
+        int maxCount = this.maxCount;
+        for (;;) {
+            int stateSnapshot = state;
+            if (isShutdown(stateSnapshot)) {
+                throw new RejectedExecutionException("Executor has been shut down");
+            }
+
+            int activeCount = getActiveCount(stateSnapshot);
+            if (activeCount >= maxCount) {
+                throw new RejectedExecutionException("No executor queue space remaining");
+            }
+            int updatedActiveCount = activeCount + 1;
+            if (compareAndSwapState(stateSnapshot, updatedActiveCount | (stateSnapshot & ~ACTIVE_COUNT_MASK))) {
+                return;
+            }
+        }
+    }
+
+    private void decrementActive() {
+        for (;;) {
+            int stateSnapshot = state;
+            int updatedActiveCount = getActiveCount(stateSnapshot) - 1;
+            int newState = updatedActiveCount | (stateSnapshot & ~ACTIVE_COUNT_MASK);
+            if (compareAndSwapState(stateSnapshot, newState)) {
+                notifyWaitersIfTerminated(newState);
+                return;
+            }
+        }
+    }
+
+    private static int getActiveCount(int state) {
+        return state & ACTIVE_COUNT_MASK;
+    }
+
+    private boolean compareAndSwapState(int expected, int update) {
+        return unsafe.compareAndSwapInt(this, stateOffset, expected, update);
+    }
+
+    @Override
+    public String toString() {
+        return "QueuelessViewExecutor{delegate=" + delegate + ", state=" + state + '}';
+    }
+
+    private final class QueuelessViewExecutorRunnable implements Runnable {
+
+        private final Runnable delegate;
+
+        @Nullable
+        private volatile Thread thread;
+
+        QueuelessViewExecutorRunnable(Runnable delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void run() {
+            Thread currentThread = Thread.currentThread();
+            Set<QueuelessViewExecutorRunnable> runnables = activeRunnables;
+            this.thread = currentThread;
+            try {
+                runnables.add(this);
+                if (interrupted) {
+                    // shutdownNow may have been invoked after this task was submitted
+                    // but prior to activeRunnables.add(this).
+                    currentThread.interrupt();
+                }
+                delegate.run();
+            } catch (Throwable t) {
+                // The uncaught exception handler should be called on the current thread in order to log
+                // using the updated thread name based on nameFunction.
+                uncaughtExceptionHandler().uncaughtException(thread, t);
+            } finally {
+                runnables.remove(this);
+                // Synchronization is important to avoid racily reading the current thread and interrupting
+                // it after this task completes and a task from another view has begun execution.
+                synchronized (this) {
+                    this.thread = null;
+                }
+                decrementActive();
+            }
+        }
+
+        private Thread.UncaughtExceptionHandler uncaughtExceptionHandler() {
+            Thread.UncaughtExceptionHandler handler = getExceptionHandler();
+            if (handler != null) {
+                return handler;
+            }
+            // If not uncaught exception handler is set, use the current threads existing handler if present.
+            // Otherwise use the default JBoss logging exception handler.
+            Thread.UncaughtExceptionHandler threadHandler =
+                    Thread.currentThread().getUncaughtExceptionHandler();
+            return threadHandler != null ? threadHandler : JBossExecutors.loggingExceptionHandler();
+        }
+
+        synchronized void interrupt() {
+            Thread taskThread = this.thread;
+            if (taskThread != null) {
+                taskThread.interrupt();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "QueuelessViewExecutorRunnable{" + delegate + '}';
+        }
+    }
+}

--- a/src/main/java/org/jboss/threads/ViewExecutor.java
+++ b/src/main/java/org/jboss/threads/ViewExecutor.java
@@ -1,229 +1,43 @@
 package org.jboss.threads;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-
-import org.jboss.logging.Logger;
 import org.wildfly.common.Assert;
-import org.wildfly.common.lock.ExtendedLock;
-import org.wildfly.common.lock.Locks;
+
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Executor;
 
 /**
  * An executor service that is actually a "view" over another executor service.
  */
-public final class ViewExecutor extends AbstractExecutorService {
-    private static final Logger log = Logger.getLogger("org.jboss.threads.view-executor");
-    private static final Runnable[] NO_RUNNABLES = new Runnable[0];
-
-    private final Executor delegate;
-
-    private final ExtendedLock lock;
-    private final Condition shutDownCondition;
-    private final ArrayDeque<Runnable> queue;
-    private final Set<TaskWrapper> allWrappers = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private int queueLimit;
-    private short submittedCount;
-    private short maxCount;
-    private short runningCount;
-    private int state = ST_RUNNING;
+public abstract class ViewExecutor extends AbstractExecutorService {
 
     private volatile Thread.UncaughtExceptionHandler handler;
     private volatile Runnable terminationTask;
 
-    private static final int ST_RUNNING = 0;
-    private static final int ST_SHUTDOWN_REQ = 1;
-    private static final int ST_SHUTDOWN_INT_REQ = 2;
-    private static final int ST_STOPPED = 3;
+    // Intentionally package private to effectively seal the type.
+    ViewExecutor() {}
 
-    ViewExecutor(final Builder builder) {
-        delegate = builder.getDelegate();
-        maxCount = (short) builder.getMaxSize();
-        final int queueLimit = builder.getQueueLimit();
-        this.queueLimit = queueLimit;
-        handler = builder.getUncaughtHandler();
-        queue = new ArrayDeque<>(Math.min(queueLimit, builder.getQueueInitialSize()));
-        lock = Locks.reentrantLock();
-        shutDownCondition = lock.newCondition();
-    }
-
-    public void execute(final Runnable command) {
-        lock.lock();
-        try {
-            if (state != ST_RUNNING) {
-                throw new RejectedExecutionException("Executor has been shut down");
-            }
-            final short submittedCount = this.submittedCount;
-            if (runningCount + submittedCount < maxCount) {
-                this.submittedCount = (short) (submittedCount + 1);
-                final TaskWrapper tw = new TaskWrapper(JBossExecutors.classLoaderPreservingTask(command));
-                allWrappers.add(tw);
-                try {
-                    /* this cannot be easily moved outside of the lock, otherwise queued tasks might never run
-                     * under certain rare scenarios.
-                     */
-                    delegate.execute(tw);
-                } catch (Throwable t) {
-                    this.submittedCount--;
-                    allWrappers.remove(tw);
-                    throw t;
-                }
-            } else if (queue.size() < queueLimit) {
-                queue.add(command);
-            } else {
-                throw new RejectedExecutionException("No executor queue space remaining");
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public void shutdown() {
+    @Override
+    public final void shutdown() {
         shutdown(false);
     }
 
-    public void shutdown(boolean interrupt) {
-        lock.lock();
-        int oldState = this.state;
-        if (oldState < ST_SHUTDOWN_REQ) {
-            // do shutdown
-            final boolean emptyQueue;
-            try {
-                emptyQueue = queue.isEmpty();
-            } catch (Throwable t) {
-                lock.unlock();
-                throw t;
-            }
-            if (runningCount == 0 && submittedCount == 0 && emptyQueue) {
-                this.state = ST_STOPPED;
-                try {
-                    shutDownCondition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
-                runTermination();
-                return;
-            }
-        }
-        // didn't exit
-        this.state = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
-        lock.unlock();
-        if (interrupt && oldState < ST_SHUTDOWN_INT_REQ) {
-            // interrupt all runners
-            for (TaskWrapper wrapper : allWrappers) {
-                wrapper.interrupt();
-            }
-        }
-    }
+    public abstract void shutdown(boolean interrupt);
 
-    public List<Runnable> shutdownNow() {
-        lock.lock();
-        int oldState = this.state;
-        final Runnable[] tasks;
-        try {
-            tasks = queue.toArray(NO_RUNNABLES);
-            queue.clear();
-        } catch (Throwable t) {
-            lock.unlock();
-            throw t;
-        }
-        if (oldState < ST_SHUTDOWN_INT_REQ) {
-            // do shutdown
-            if (runningCount == 0 && submittedCount == 0) {
-                this.state = ST_STOPPED;
-                try {
-                    shutDownCondition.signalAll();
-                } finally {
-                    lock.unlock();
-                }
-                runTermination();
-            } else {
-                lock.unlock();
-                this.state = ST_SHUTDOWN_INT_REQ;
-                // interrupt all runners
-                for (TaskWrapper wrapper : allWrappers) {
-                    wrapper.interrupt();
-                }
-            }
-        } else {
-            lock.unlock();
-        }
-        return Arrays.asList(tasks);
-    }
-
-    public boolean isShutdown() {
-        lock.lock();
-        try {
-            return state >= ST_SHUTDOWN_REQ;
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public boolean isTerminated() {
-        lock.lock();
-        try {
-            return state == ST_STOPPED;
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
-        lock.lock();
-        try {
-            if (state == ST_STOPPED) {
-                return true;
-            }
-            final long nanos = unit.toNanos(timeout);
-            if (nanos <= 0) {
-                return false;
-            }
-            long elapsed = 0;
-            final long start = System.nanoTime();
-            for (;;) {
-                shutDownCondition.awaitNanos(nanos - elapsed);
-                if (state == ST_STOPPED) {
-                    return true;
-                }
-                elapsed = System.nanoTime() - start;
-                if (elapsed >= nanos) {
-                    return false;
-                }
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public Thread.UncaughtExceptionHandler getExceptionHandler() {
+    public final Thread.UncaughtExceptionHandler getExceptionHandler() {
         return handler;
     }
 
-    public void setExceptionHandler(final Thread.UncaughtExceptionHandler handler) {
+    public final void setExceptionHandler(final Thread.UncaughtExceptionHandler handler) {
         Assert.checkNotNullParam("handler", handler);
         this.handler = handler;
     }
 
-    public Runnable getTerminationTask() {
+    public final Runnable getTerminationTask() {
         return terminationTask;
     }
 
-    public void setTerminationTask(final Runnable terminationTask) {
+    public final void setTerminationTask(final Runnable terminationTask) {
         this.terminationTask = terminationTask;
-    }
-
-    public String toString() {
-        return "view of " + delegate;
     }
 
     public static Builder builder(Executor delegate) {
@@ -286,100 +100,30 @@ public final class ViewExecutor extends AbstractExecutorService {
         }
 
         public ViewExecutor build() {
-            return new ViewExecutor(this);
+            if (queueLimit == 0) {
+                return new QueuelessViewExecutor(Assert.checkNotNullParam("delegate", delegate), maxSize, handler);
+            }
+            return new QueuedViewExecutor(
+                    Assert.checkNotNullParam("delegate", delegate),
+                    maxSize,
+                    queueLimit,
+                    queueInitialSize,
+                    handler);
         }
     }
 
-    class TaskWrapper implements Runnable {
-        private volatile Thread thread;
-        private Runnable command;
-
-        TaskWrapper(final Runnable command) {
-            this.command = command;
-        }
-
-        void interrupt() {
-            final Thread thread = this.thread;
-            if (thread != null) {
-                thread.interrupt();
-            }
-        }
-
-        public void run() {
-            boolean removeFromAllWrappersAfterCompletion = true;
-            thread = Thread.currentThread();
-            try {
-                for (;;) {
-                    lock.lock();
-                    try {
-                        submittedCount--;
-                        runningCount++;
-                    } finally {
-                        lock.unlock();
-                    }
-                    try {
-                        command.run();
-                    } catch (Throwable t) {
-                        try {
-                            handler.uncaughtException(Thread.currentThread(), t);
-                        } catch (Throwable ignored) {
-                        }
-                    }
-                    lock.lock();
-                    runningCount--;
-                    try {
-                        command = queue.pollFirst();
-                    } catch (Throwable t) {
-                        lock.unlock();
-                        throw t;
-                    }
-                    if (runningCount + submittedCount < maxCount && command != null) {
-                        // execute next
-                        submittedCount++;
-                        lock.unlock();
-                    } else if (command == null && runningCount == 0 && submittedCount == 0 && state != ST_RUNNING) {
-                        // we're the last task
-                        state = ST_STOPPED;
-                        try {
-                            shutDownCondition.signalAll();
-                        } finally {
-                            lock.unlock();
-                        }
-                        runTermination();
-                        return;
-                    } else {
-                        lock.unlock();
-                        return;
-                    }
-                    try {
-                        delegate.execute(this);
-                        removeFromAllWrappersAfterCompletion = false;
-                        // resubmitted this task for execution, so return
-                        return;
-                    } catch (Throwable t) {
-                        log.warn("Failed to resubmit executor task to delegate executor"
-                            + " (executing task immediately instead)", t);
-                        // resubmit failed, so continue execution in this thread
-                    }
-                }
-            } finally {
-                if (removeFromAllWrappersAfterCompletion) {
-                    allWrappers.remove(this);
-                }
-                thread = null;
-            }
-        }
-    }
-
-    private void runTermination() {
+    protected void runTermination() {
         final Runnable task = ViewExecutor.this.terminationTask;
         ViewExecutor.this.terminationTask = null;
         if (task != null) try {
             task.run();
         } catch (Throwable t) {
-            try {
-                handler.uncaughtException(Thread.currentThread(), t);
-            } catch (Throwable ignored) {
+            Thread.UncaughtExceptionHandler configuredHandler = handler;
+            if (configuredHandler != null) {
+                try {
+                    handler.uncaughtException(Thread.currentThread(), t);
+                } catch (Throwable ignored) {
+                }
             }
         }
     }

--- a/src/test/java/org/jboss/threads/QueuelessViewExecutorTest.java
+++ b/src/test/java/org/jboss/threads/QueuelessViewExecutorTest.java
@@ -1,0 +1,197 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.threads;
+
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class QueuelessViewExecutorTest {
+
+    private static final String THREAD_BASE_NAME = "CachedExecutorViewTest-";
+
+    @Test
+    public void testShutdownNow() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = cachedExecutor();
+        ExecutorService view = ViewExecutor.builder(cached).setQueueLimit(0).setMaxSize(Short.MAX_VALUE).build();
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        CountDownLatch executionStartedLatch = new CountDownLatch(1);
+        CountDownLatch interruptedLatch = new CountDownLatch(1);
+        view.execute(() -> {
+            try {
+                executionStartedLatch.countDown();
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+                // Wait so we can validate the time between shutdown and terminated
+                try {
+                    interruptedLatch.await();
+                } catch (InterruptedException ee) {
+                    throw new AssertionError(ee);
+                }
+            }
+        });
+        executionStartedLatch.await();
+        assertThat(view.shutdownNow()).as("Cached executors have no queue").isEmpty();
+        assertThat(view.isShutdown()).isTrue();
+        assertThatThrownBy(() -> view.execute(NullRunnable.getInstance()))
+                .as("Submitting work after invoking shutdown or shutdownNow should fail")
+                .isInstanceOf(RejectedExecutionException.class);
+        Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            assertThat(interrupted).isTrue();
+            assertThat(view.isTerminated()).isFalse();
+        });
+        interruptedLatch.countDown();
+        Awaitility.waitAtMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(view.isTerminated()).isTrue());
+
+        assertCleanShutdown(cached);
+    }
+
+    @Test
+    public void testShutdownNow_immediatelyAfterTaskIsSubmitted() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = cachedExecutor();
+        ExecutorService view = ViewExecutor.builder(runnable -> {
+            cached.execute(() -> {
+                // Emphasize the jitter between when a task is submitted, and when it begins to execute
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
+                runnable.run();
+            });
+        }).setQueueLimit(0).setMaxSize(Short.MAX_VALUE).build();
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        view.execute(() -> {
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+        assertThat(view.shutdownNow()).as("Cached executors have no queue").isEmpty();
+        assertThat(view.awaitTermination(3, TimeUnit.SECONDS))
+                .as("View failed to terminate within 3 seconds")
+                .isTrue();
+        assertThat(interrupted).as("Task should have been interrupted").isTrue();
+
+        assertCleanShutdown(cached);
+    }
+
+    @Test(timeout = 5_000) // Failing awaitTermination should return quickly
+    public void testAwaitTermination() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = cachedExecutor();
+        ExecutorService view = ViewExecutor.builder(cached).setQueueLimit(0).setMaxSize(Short.MAX_VALUE).build();
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        view.execute(() -> {
+            try {
+                Thread.sleep(30_000);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+
+        view.shutdown();
+        assertThat(view.awaitTermination(10, TimeUnit.MILLISECONDS))
+                .as("Task should not have been interrupted, and is still sleeping")
+                .isFalse();
+
+        assertThat(interrupted).as("Task should not be interrupted by 'shutdown'").isFalse();
+
+        assertThat(view.shutdownNow()).as("Cached executors have no queue").isEmpty();
+        assertThat(view.awaitTermination(3, TimeUnit.SECONDS))
+                .as("Task should have been interrupted")
+                .isTrue();
+
+        assertThat(interrupted).as("Task should be interrupted by 'shutdownNow'").isTrue();
+
+        assertCleanShutdown(cached);
+    }
+
+    @Test
+    public void testShutdown() throws InterruptedException {
+        AtomicBoolean interrupted = new AtomicBoolean();
+        ExecutorService cached = cachedExecutor();
+        ExecutorService view = ViewExecutor.builder(cached).setQueueLimit(0).setMaxSize(Short.MAX_VALUE).build();
+        assertThat(view.isShutdown()).isEqualTo(cached.isShutdown()).isFalse();
+        assertThat(view.isTerminated()).isEqualTo(cached.isTerminated()).isFalse();
+        CountDownLatch executionStartedLatch = new CountDownLatch(1);
+        view.execute(() -> {
+            try {
+                executionStartedLatch.countDown();
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+            }
+        });
+        executionStartedLatch.await();
+        view.shutdown();
+        assertThat(view.isShutdown()).isTrue();
+        assertThatThrownBy(() -> view.execute(NullRunnable.getInstance()))
+                .as("Submitting work after invoking shutdown or shutdown should fail")
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(view.isTerminated()).isFalse();
+        Awaitility.waitAtMost(600, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(view.isTerminated()).isTrue());
+        assertThat(interrupted).isFalse();
+
+        assertCleanShutdown(cached);
+    }
+
+    private static ExecutorService cachedExecutor() {
+        AtomicInteger index = new AtomicInteger();
+        return Executors.newCachedThreadPool(
+                task -> {
+                    Thread thread = new Thread(task);
+                    thread.setDaemon(true);
+                    thread.setName(THREAD_BASE_NAME + index.getAndIncrement());
+                    return thread;
+                });
+    }
+
+    private static void assertCleanShutdown(ExecutorService executor) {
+        assertThat(executor.isShutdown()).isFalse();
+        assertThat(executor.isTerminated()).isFalse();
+        executor.shutdown();
+        try {
+            assertThat(executor.awaitTermination(1, TimeUnit.SECONDS))
+                    .as("Failed to clean up the executor")
+                    .isTrue();
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
This allows us to provide references to the same underlying pool of
threads to different consumers and utilize distinct thread name patterns
and instrumentation without duplicating resources.