### PR TITLE
Add missing JUnit test annotation to ViewExecutorTest.testInterruptedShutdown

### DIFF
--- a/src/test/java/org/jboss/threads/ViewExecutorTest.java
+++ b/src/test/java/org/jboss/threads/ViewExecutorTest.java
@@ -81,6 +81,7 @@ public final class ViewExecutorTest {
         assertEquals(0, executedTasks.size());
     }
 
+    @Test
     public void testInterruptedShutdown() throws InterruptedException {
         ExecutorService testExecutor = Executors.newSingleThreadExecutor();
         final ViewExecutor ve = ViewExecutor.builder(testExecutor).build();


### PR DESCRIPTION
It doesn't appear that this annotation was intentionally excluded