### PR TITLE
JBTHR-87: Fix a memory leak in ViewExecutor

### DIFF
--- a/src/main/java/org/jboss/threads/ViewExecutor.java
+++ b/src/main/java/org/jboss/threads/ViewExecutor.java
@@ -306,6 +306,7 @@ public final class ViewExecutor extends AbstractExecutorService {
         }
 
         public void run() {
+            boolean removeFromAllWrappersAfterCompletion = true;
             thread = Thread.currentThread();
             try {
                 for (;;) {
@@ -352,6 +353,7 @@ public final class ViewExecutor extends AbstractExecutorService {
                     }
                     try {
                         delegate.execute(this);
+                        removeFromAllWrappersAfterCompletion = false;
                         // resubmitted this task for execution, so return
                         return;
                     } catch (Throwable t) {
@@ -361,6 +363,9 @@ public final class ViewExecutor extends AbstractExecutorService {
                     }
                 }
             } finally {
+                if (removeFromAllWrappersAfterCompletion) {
+                    allWrappers.remove(this);
+                }
                 thread = null;
             }
         }

--- a/src/test/java/org/jboss/threads/ViewExecutorTest.java
+++ b/src/test/java/org/jboss/threads/ViewExecutorTest.java
@@ -108,6 +108,31 @@ public final class ViewExecutorTest {
         assertTrue(testExecutor.awaitTermination(5L, TimeUnit.SECONDS));
     }
 
+    // TaskWrapper instances are relatively small and take a long time to knock over a JVM,
+    // however when they aren't collected properly they will cause a GC spiral for much longer
+    // than ten seconds. Unfortunately this test is impacted by hardware changes and may flake
+    // (or erroneously pass on fast enough hardware).
+    @Test(timeout = 10_000)
+    public void testViewExecutorMemoryOverhead() {
+        Executor directExecutor = new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                try {
+                    command.run();
+                } catch (Throwable t) {
+                    Thread currentThread = Thread.currentThread();
+                    currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, t);
+                }
+            }
+        };
+        ExecutorService executorService = ViewExecutor.builder(directExecutor).build();
+        for (long i = 0; i < 20_000_000L; i++) {
+            executorService.execute(JBossExecutors.nullRunnable());
+        }
+        executorService.shutdown();
+        assertTrue(executorService.isTerminated());
+    }
+
     private static class QueuedExecutor implements Executor {
         private final ArrayDeque<Runnable> executedTasks;
 


### PR DESCRIPTION
TaskWrapper refernces are removed once their lifecycle has
completed.

https://issues.redhat.com/browse/JBTHR-87