### PR TITLE
Fix shutdown behvaior on terminated QueuedViewExecutors

### DIFF
--- a/src/main/java/org/jboss/threads/QueuedViewExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuedViewExecutor.java
@@ -110,8 +110,11 @@ final class QueuedViewExecutor extends ViewExecutor {
                 return;
             }
         }
-        // didn't exit
-        this.state = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
+        // didn't exit, or already completed
+        int newState = interrupt ? ST_SHUTDOWN_INT_REQ : ST_SHUTDOWN_REQ;
+        if (newState > oldState) {
+            this.state = newState;
+        }
         lock.unlock();
         if (interrupt && oldState < ST_SHUTDOWN_INT_REQ) {
             // interrupt all runners

--- a/src/test/java/org/jboss/threads/ViewExecutorTest.java
+++ b/src/test/java/org/jboss/threads/ViewExecutorTest.java
@@ -52,6 +52,8 @@ public final class ViewExecutorTest {
         assertTrue(ve.isShutdown());
         assertTrue(ve.awaitTermination(10L, TimeUnit.SECONDS));
         assertTrue(ve.isTerminated());
+        ve.shutdown();
+        assertTrue(ve.isTerminated());
     }
 
     @Test


### PR DESCRIPTION
Previously state would revert from ST_STOPPED to ST_SHUTDOWN_REQ
with no submitted, running, or queued tasks.