### PR TITLE
Fix JBossThread interrupt spins on single core systems

### DIFF
--- a/src/main/java/org/jboss/threads/JBossThread.java
+++ b/src/main/java/org/jboss/threads/JBossThread.java
@@ -47,7 +47,7 @@ public class JBossThread extends Thread {
     private static final RuntimePermission MODIFY_THREAD_PERMISSION = new RuntimePermission("modifyThread");
     private static final int MAX_INTERRUPT_SPINS = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
         public Integer run() {
-            return Integer.valueOf(Integer.parseInt(System.getProperty("jboss.threads.interrupt.spins", ProcessorInfo.availableProcessors() == 0 ? "0" : "128")));
+            return Integer.valueOf(Integer.parseInt(System.getProperty("jboss.threads.interrupt.spins", ProcessorInfo.availableProcessors() == 1 ? "0" : "128")));
         }
     }).intValue();
 


### PR DESCRIPTION
Spinning is avoid in favor of yielding immediately when there's
a single core.