### PR TITLE
Classloader preservation is configurable

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -189,6 +189,11 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
      */
     private final AccessControlContext acc;
 
+    /**
+     * Whether incoming tasks are wrapped using {@link JBossExecutors#classLoaderPreservingTaskUnchecked(Runnable)}.
+     */
+    private final boolean preserveContextClassLoaders;
+
     // =======================================================
     // Current state fields
     // =======================================================
@@ -351,6 +356,7 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         this.threadFactory = builder.getThreadFactory();
         this.terminationTask = builder.getTerminationTask();
         this.growthResistance = builder.getGrowthResistance();
+        this.preserveContextClassLoaders = builder.preserveContextClassLoaders;
         final Duration keepAliveTime = builder.getKeepAliveTime();
         // initial dead node
         // thread stat
@@ -409,6 +415,7 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
         private int maxQueueSize = Integer.MAX_VALUE;
         private boolean registerMBean = REGISTER_MBEAN;
         private String mBeanName;
+        private boolean preserveContextClassLoaders = true;
 
         /**
          * Construct a new instance.
@@ -731,6 +738,26 @@ public final class EnhancedQueueExecutor extends EnhancedQueueExecutorBase6 impl
          */
         public Builder setMBeanName(final String mBeanName) {
             this.mBeanName = mBeanName;
+            return this;
+        }
+
+        /**
+         * Returns true if submitting threads context classloaders are preserved.
+         *
+         * @see #setPreserveContextClassLoaders(boolean)
+         */
+        public boolean getPreserveContextClassLoaders() {
+            return preserveContextClassLoaders;
+        }
+
+        /**
+         * Configures whether tasks submitted to this executor will preserve the callers context classloader.
+         * By default context class loaders are preserved.
+         *
+         * @see JBossExecutors#classLoaderPreservingTaskUnchecked(Runnable)
+         */
+        public Builder setPreserveContextClassLoaders(final boolean preserveContextClassLoaders) {
+            this.preserveContextClassLoaders = preserveContextClassLoaders;
             return this;
         }
     }

--- a/src/main/java/org/jboss/threads/ViewExecutor.java
+++ b/src/main/java/org/jboss/threads/ViewExecutor.java
@@ -50,6 +50,7 @@ public abstract class ViewExecutor extends AbstractExecutorService {
         private short maxSize = 1;
         private int queueLimit = Integer.MAX_VALUE;
         private int queueInitialSize = 256;
+        private boolean preserveContextClassLoaders = true;
         private Thread.UncaughtExceptionHandler handler = JBossExecutors.loggingExceptionHandler();
 
         Builder(final Executor delegate) {
@@ -99,15 +100,40 @@ public abstract class ViewExecutor extends AbstractExecutorService {
             return this;
         }
 
+        /**
+         * Returns true if submitting threads context classloaders are preserved.
+         *
+         * @see #setPreserveContextClassLoaders(boolean)
+         */
+        public boolean getPreserveContextClassLoaders() {
+            return preserveContextClassLoaders;
+        }
+
+        /**
+         * Configures whether tasks submitted to this executor will preserve the callers context classloader.
+         * By default context class loaders are preserved.
+         *
+         * @see JBossExecutors#classLoaderPreservingTaskUnchecked(Runnable)
+         */
+        public Builder setPreserveContextClassLoaders(final boolean preserveContextClassLoaders) {
+            this.preserveContextClassLoaders = preserveContextClassLoaders;
+            return this;
+        }
+
         public ViewExecutor build() {
             if (queueLimit == 0) {
-                return new QueuelessViewExecutor(Assert.checkNotNullParam("delegate", delegate), maxSize, handler);
+                return new QueuelessViewExecutor(
+                        Assert.checkNotNullParam("delegate", delegate),
+                        maxSize,
+                        preserveContextClassLoaders,
+                        handler);
             }
             return new QueuedViewExecutor(
                     Assert.checkNotNullParam("delegate", delegate),
                     maxSize,
                     queueLimit,
                     queueInitialSize,
+                    preserveContextClassLoaders,
                     handler);
         }
     }


### PR DESCRIPTION
This updates QueuedViewExecutor to use the unchecked variation of
the task factory, and adds support for classloader preservation
to the queueless implementation.

This enhances the EQE builder to support configurable classloader
preservation in order to avoid wrapping tasks multiple times when
an EQE is used as a base executor and only used through views.