### PR TITLE
Both queued executors preserve the callers ccl

### DIFF
--- a/src/main/java/org/jboss/threads/QueuedViewExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuedViewExecutor.java
@@ -63,7 +63,7 @@ final class QueuedViewExecutor extends ViewExecutor {
             final short submittedCount = this.submittedCount;
             if (runningCount + submittedCount < maxCount) {
                 this.submittedCount = (short) (submittedCount + 1);
-                final TaskWrapper tw = new TaskWrapper(JBossExecutors.classLoaderPreservingTask(command));
+                final TaskWrapper tw = new TaskWrapper(JBossExecutors.classLoaderPreservingTaskUnchecked(command));
                 allWrappers.add(tw);
                 try {
                     /* this cannot be easily moved outside of the lock, otherwise queued tasks might never run

--- a/src/main/java/org/jboss/threads/QueuelessViewExecutor.java
+++ b/src/main/java/org/jboss/threads/QueuelessViewExecutor.java
@@ -159,7 +159,8 @@ final class QueuelessViewExecutor extends ViewExecutor {
         boolean submittedTask = false;
         try {
             // When CachedExecutorViewRunnable allocation fails the active count must be reduced.
-            delegate.execute(new QueuelessViewExecutorRunnable(task));
+            delegate.execute(new QueuelessViewExecutorRunnable(
+                    JBossExecutors.classLoaderPreservingTaskUnchecked(task)));
             submittedTask = true;
         } finally {
             if (!submittedTask) decrementActive();


### PR DESCRIPTION
This also updates the queued view executor to use the unchecked methd,
matching the EnhancedQueueExecutor.