### PR TITLE
Remove the ViewExecutor artificial size limit

### DIFF
--- a/src/main/java/org/jboss/threads/ViewExecutor.java
+++ b/src/main/java/org/jboss/threads/ViewExecutor.java
@@ -50,7 +50,7 @@ public abstract class ViewExecutor extends AbstractExecutorService {
 
     public static final class Builder {
         private final Executor delegate;
-        private short maxSize = 1;
+        private int maxSize = 1;
         private int queueLimit = Integer.MAX_VALUE;
         private Thread.UncaughtExceptionHandler handler = JBossExecutors.loggingExceptionHandler();
 
@@ -64,8 +64,7 @@ public abstract class ViewExecutor extends AbstractExecutorService {
 
         public Builder setMaxSize(final int maxSize) {
             Assert.checkMinimumParameter("maxSize", 1, maxSize);
-            Assert.checkMaximumParameter("maxSize", Short.MAX_VALUE, maxSize);
-            this.maxSize = (short) maxSize;
+            this.maxSize = maxSize;
             return this;
         }
 


### PR DESCRIPTION
Unlike the previous implementations, EnhancedViewExecutor stores
state in a 64-bit integer, allowing both the pool and queue
sizes to use full integers.

There's not any reason to create an executor with more than 32k
active tasks, however the builder uses the `int` type so it's nice
to allow `Integer.MAX_VALUE` to have effectively the same impact
as `Short.MAX_VALUE` and rely on the compiler for input validation.