### PR TITLE
Display the version in DEBUG level

### DIFF
--- a/src/main/java/org/jboss/threads/Messages.java
+++ b/src/main/java/org/jboss/threads/Messages.java
@@ -39,7 +39,7 @@ interface Messages extends BasicLogger {
 
     // version
     @Message(value = "JBoss Threads version %s")
-    @LogMessage(level = Logger.Level.INFO)
+    @LogMessage(level = Logger.Level.DEBUG)
     void version(String version);
 
     // execution


### PR DESCRIPTION
Showing the version pollutes the log and it's pretty useless unless you're well, debugging :)

/cc @dmlloyd 