### PR TITLE
Add `module-info`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,19 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-constraint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-cpu</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-function</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
         <jdk.min.version>11</jdk.min.version>
 
-        <version.jboss.logging.tools>3.0.0.Final</version.jboss.logging.tools>
+        <version.jboss.logging.tools>3.0.1.Final</version.jboss.logging.tools>
     </properties>
 
     <dependencyManagement>
@@ -97,12 +97,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-            <version>${version.jboss.logging.tools}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
             <version>${version.jboss.logging.tools}</version>
             <scope>provided</scope>
         </dependency>
@@ -189,7 +183,17 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <proc>full</proc>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.jboss.logging</groupId>
+                            <artifactId>jboss-logging-processor</artifactId>
+                            <version>${version.jboss.logging.tools}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <!-- This is for SVM dependency -->
+                        <compilerArg>--add-reads=org.jboss.threads=ALL-UNNAMED</compilerArg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
@@ -205,6 +209,7 @@
                         <jboss.threads.eqe.unlimited-queue>${jboss.threads.eqe.unlimited-queue}</jboss.threads.eqe.unlimited-queue>
                         <jboss.threads.eqe.register-mbean>${jboss.threads.eqe.register-mbean}</jboss.threads.eqe.register-mbean>
                     </systemPropertyVariables>
+                    <useModulePath>true</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module org.jboss.threads {
+    requires java.management;
+    requires jdk.unsupported;
+    requires org.jboss.logging;
+    requires static org.jboss.logging.annotations;
+    requires org.wildfly.common;
+    requires io.smallrye.common.annotation;
+    requires io.smallrye.common.constraint;
+    requires io.smallrye.common.cpu;
+    requires io.smallrye.common.function;
+
+    exports org.jboss.threads;
+    exports org.jboss.threads.management;
+}

--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -51,8 +51,8 @@ import io.smallrye.common.cpu.CacheInfo;
 import org.jboss.threads.management.ManageableThreadPoolExecutorService;
 import org.jboss.threads.management.StandardThreadPoolMXBean;
 
-import org.wildfly.common.Assert;
-import org.wildfly.common.cpu.ProcessorInfo;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.cpu.ProcessorInfo;
 
 /**
  * A task-or-thread queue backed thread pool executor service.  Tasks are added in a FIFO manner, and consumers in a LIFO manner.

--- a/src/main/java/org/jboss/threads/EnhancedViewExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedViewExecutor.java
@@ -1,10 +1,9 @@
 package org.jboss.threads;
 
 import org.jboss.logging.Logger;
-import org.wildfly.common.Assert;
-import org.wildfly.common.annotation.Nullable;
-import org.wildfly.common.cpu.ProcessorInfo;
-import org.wildfly.common.lock.Locks;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.constraint.Nullable;
+import io.smallrye.common.cpu.ProcessorInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,6 +16,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.jboss.threads.JBossExecutors.unsafe;
 
@@ -100,7 +100,7 @@ final class EnhancedViewExecutor extends ViewExecutor {
         this.executeLock = queueLimit == 0
                 ? null
                 // Lock must be reentrant to handle same-thread executors or CallerRunsPolicy
-                : Locks.reentrantLock();
+                : new ReentrantLock();
         this.setExceptionHandler(uncaughtExceptionHandler);
     }
 

--- a/src/main/java/org/jboss/threads/JBossExecutors.java
+++ b/src/main/java/org/jboss/threads/JBossExecutors.java
@@ -11,7 +11,7 @@ import java.security.PrivilegedAction;
 import java.security.AccessController;
 
 import org.jboss.logging.Logger;
-import org.wildfly.common.Assert;
+import io.smallrye.common.constraint.Assert;
 import sun.misc.Unsafe;
 
 /**

--- a/src/main/java/org/jboss/threads/JBossThread.java
+++ b/src/main/java/org/jboss/threads/JBossThread.java
@@ -9,8 +9,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
-import org.wildfly.common.Assert;
-import org.wildfly.common.cpu.ProcessorInfo;
+import io.smallrye.common.constraint.Assert;
+import io.smallrye.common.cpu.ProcessorInfo;
 import org.wildfly.common.function.ExceptionBiConsumer;
 import org.wildfly.common.function.ExceptionBiFunction;
 import org.wildfly.common.function.ExceptionConsumer;
@@ -19,7 +19,6 @@ import org.wildfly.common.function.ExceptionObjIntConsumer;
 import org.wildfly.common.function.ExceptionObjLongConsumer;
 import org.wildfly.common.function.ExceptionRunnable;
 import org.wildfly.common.function.ExceptionSupplier;
-import org.wildfly.common.function.Functions;
 
 /**
  * A JBoss thread.  Supports logging and extra operations.
@@ -255,6 +254,7 @@ public class JBossThread extends Thread {
      * @param <T> the action's return type
      * @return the value returned from the callable
      */
+    @Deprecated
     public static <T> T executeWithInterruptDeferred(final PrivilegedAction<T> action) {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -277,6 +277,7 @@ public class JBossThread extends Thread {
      * @return the value returned from the callable
      * @throws Exception if the action throws an exception
      */
+    @Deprecated
     public static <T> T executeWithInterruptDeferred(final PrivilegedExceptionAction<T> action) throws Exception {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -289,6 +290,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, U, R, E extends Exception> R applyInterruptDeferredEx(final ExceptionBiFunction<T, U, R, E> function, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -301,14 +303,17 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, R, E extends Exception> R applyInterruptDeferredEx(final ExceptionFunction<T, R, E> function, T param) throws E {
-        return applyInterruptDeferredEx(Functions.exceptionFunctionBiFunction(), function, param);
+        return applyInterruptDeferredEx(ExceptionFunction::apply, function, param);
     }
 
+    @Deprecated
     public static <T, E extends Exception> T getInterruptDeferredEx(final ExceptionSupplier<T, E> supplier) throws E {
-        return applyInterruptDeferredEx(Functions.exceptionFunctionBiFunction(), Functions.exceptionSupplierFunction(), supplier);
+        return applyInterruptDeferredEx(ExceptionSupplier::get, supplier);
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptDeferredEx(final ExceptionObjLongConsumer<T, E> consumer, T param1, long param2) throws E {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -321,6 +326,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptDeferredEx(final ExceptionObjIntConsumer<T, E> consumer, T param1, int param2) throws E {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -333,6 +339,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, U, E extends Exception> void acceptInterruptDeferredEx(final ExceptionBiConsumer<T, U, E> consumer, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (registerDeferral(thread)) try {
@@ -345,15 +352,17 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptDeferredEx(final ExceptionConsumer<T, E> consumer, T param) throws E {
-        acceptInterruptDeferredEx(Functions.exceptionConsumerBiConsumer(), consumer, param);
+        acceptInterruptDeferredEx(ExceptionConsumer::accept, consumer, param);
     }
 
+    @Deprecated
     public static <E extends Exception> void runInterruptDeferredEx(final ExceptionRunnable<E> runnable) throws E {
-        acceptInterruptDeferredEx(Functions.exceptionConsumerBiConsumer(), Functions.exceptionRunnableConsumer(), runnable);
+        acceptInterruptDeferredEx(ExceptionRunnable::run, runnable);
     }
 
-
+    @Deprecated
     public static <T, U, R, E extends Exception> R applyInterruptResumedEx(final ExceptionBiFunction<T, U, R, E> function, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (unregisterDeferral(thread)) try {
@@ -366,14 +375,17 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, R, E extends Exception> R applyInterruptResumedEx(final ExceptionFunction<T, R, E> function, T param) throws E {
-        return applyInterruptResumedEx(Functions.exceptionFunctionBiFunction(), function, param);
+        return applyInterruptResumedEx(ExceptionFunction::apply, function, param);
     }
 
+    @Deprecated
     public static <T, E extends Exception> T getInterruptResumedEx(final ExceptionSupplier<T, E> supplier) throws E {
-        return applyInterruptResumedEx(Functions.exceptionFunctionBiFunction(), Functions.exceptionSupplierFunction(), supplier);
+        return applyInterruptResumedEx(ExceptionSupplier::get, supplier);
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptResumedEx(final ExceptionObjLongConsumer<T, E> consumer, T param1, long param2) throws E {
         final JBossThread thread = currentThread();
         if (unregisterDeferral(thread)) try {
@@ -386,6 +398,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptResumedEx(final ExceptionObjIntConsumer<T, E> consumer, T param1, int param2) throws E {
         final JBossThread thread = currentThread();
         if (unregisterDeferral(thread)) try {
@@ -398,6 +411,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, U, E extends Exception> void acceptInterruptResumedEx(final ExceptionBiConsumer<T, U, E> consumer, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (unregisterDeferral(thread)) try {
@@ -410,12 +424,14 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptInterruptResumedEx(final ExceptionConsumer<T, E> consumer, T param) throws E {
-        acceptInterruptResumedEx(Functions.exceptionConsumerBiConsumer(), consumer, param);
+        acceptInterruptResumedEx(ExceptionConsumer::accept, consumer, param);
     }
 
+    @Deprecated
     public static <E extends Exception> void runInterruptResumedEx(final ExceptionRunnable<E> runnable) throws E {
-        acceptInterruptResumedEx(Functions.exceptionConsumerBiConsumer(), Functions.exceptionRunnableConsumer(), runnable);
+        acceptInterruptResumedEx(ExceptionRunnable::run, runnable);
     }
 
     private static boolean unregisterDeferral(final JBossThread thread) {
@@ -578,6 +594,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, U, R, E extends Exception> R applyWithInterruptHandler(InterruptHandler interruptHandler, ExceptionBiFunction<T, U, R, E> function, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (thread == null) {
@@ -593,14 +610,17 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, R, E extends Exception> R applyWithInterruptHandler(InterruptHandler interruptHandler, ExceptionFunction<T, R, E> function, T param1) throws E {
-        return applyWithInterruptHandler(interruptHandler, Functions.exceptionFunctionBiFunction(), function, param1);
+        return applyWithInterruptHandler(interruptHandler, ExceptionFunction::apply, function, param1);
     }
 
+    @Deprecated
     public static <R, E extends Exception> R getWithInterruptHandler(InterruptHandler interruptHandler, ExceptionSupplier<R, E> function) throws E {
-        return applyWithInterruptHandler(interruptHandler, Functions.exceptionFunctionBiFunction(), Functions.exceptionSupplierFunction(), function);
+        return applyWithInterruptHandler(interruptHandler, ExceptionSupplier::get, function);
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptWithInterruptHandler(InterruptHandler interruptHandler, ExceptionObjLongConsumer<T, E> function, T param1, long param2) throws E {
         final JBossThread thread = currentThread();
         if (thread == null) {
@@ -618,6 +638,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptWithInterruptHandler(InterruptHandler interruptHandler, ExceptionObjIntConsumer<T, E> function, T param1, int param2) throws E {
         final JBossThread thread = currentThread();
         if (thread == null) {
@@ -635,6 +656,7 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, U, E extends Exception> void acceptWithInterruptHandler(InterruptHandler interruptHandler, ExceptionBiConsumer<T, U, E> function, T param1, U param2) throws E {
         final JBossThread thread = currentThread();
         if (thread == null) {
@@ -652,12 +674,14 @@ public class JBossThread extends Thread {
         }
     }
 
+    @Deprecated
     public static <T, E extends Exception> void acceptWithInterruptHandler(InterruptHandler interruptHandler, ExceptionConsumer<T, E> function, T param1) throws E {
-        acceptWithInterruptHandler(interruptHandler, Functions.exceptionConsumerBiConsumer(), function, param1);
+        acceptWithInterruptHandler(interruptHandler, ExceptionConsumer::accept, function, param1);
     }
 
+    @Deprecated
     public static <E extends Exception> void runWithInterruptHandler(InterruptHandler interruptHandler, ExceptionRunnable<E> function) throws E {
-        acceptWithInterruptHandler(interruptHandler, Functions.exceptionConsumerBiConsumer(), Functions.exceptionRunnableConsumer(), function);
+        acceptWithInterruptHandler(interruptHandler, ExceptionRunnable::run, function);
     }
 
     /**

--- a/src/main/java/org/jboss/threads/ManagedThreadPoolExecutor.java
+++ b/src/main/java/org/jboss/threads/ManagedThreadPoolExecutor.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jboss.threads.management.ManageableThreadPoolExecutorService;
 import org.jboss.threads.management.StandardThreadPoolMXBean;
-import org.wildfly.common.Assert;
+import io.smallrye.common.constraint.Assert;
 
 /**
  * A version of {@link ThreadPoolExecutor} which implements {@link ManageableThreadPoolExecutorService} in order to allow

--- a/src/main/java/org/jboss/threads/Messages.java
+++ b/src/main/java/org/jboss/threads/Messages.java
@@ -1,5 +1,7 @@
 package org.jboss.threads;
 
+import static java.lang.invoke.MethodHandles.*;
+
 import java.time.Duration;
 
 import org.jboss.logging.BasicLogger;
@@ -14,8 +16,8 @@ import org.jboss.logging.annotations.MessageLogger;
  */
 @MessageLogger(projectCode = "JBTHR", length = 5)
 interface Messages extends BasicLogger {
-    Messages msg = Logger.getMessageLogger(Messages.class, "org.jboss.threads");
-    Messages intMsg = Logger.getMessageLogger(Messages.class, "org.jboss.threads.interrupt-handler");
+    Messages msg = Logger.getMessageLogger(lookup(), Messages.class, "org.jboss.threads");
+    Messages intMsg = Logger.getMessageLogger(lookup(), Messages.class, "org.jboss.threads.interrupt-handler");
 
     // version
     @Message(value = "JBoss Threads version %s")

--- a/src/main/java/org/jboss/threads/ViewExecutor.java
+++ b/src/main/java/org/jboss/threads/ViewExecutor.java
@@ -1,6 +1,6 @@
 package org.jboss.threads;
 
-import org.wildfly.common.Assert;
+import io.smallrye.common.constraint.Assert;
 
 import java.security.PrivilegedAction;
 import java.util.concurrent.AbstractExecutorService;

--- a/src/main/java/org/jboss/threads/management/ManageableThreadPoolExecutorService.java
+++ b/src/main/java/org/jboss/threads/management/ManageableThreadPoolExecutorService.java
@@ -2,7 +2,7 @@ package org.jboss.threads.management;
 
 import java.util.concurrent.ExecutorService;
 
-import org.wildfly.common.annotation.NotNull;
+import io.smallrye.common.constraint.NotNull;
 
 /**
  * A thread pool for which an MBean can be obtained.


### PR DESCRIPTION
This draft PR adds a `module-info` descriptor to `jboss-threads`. Before this can come out of draft, the following prerequisites have to be met:

- [x] JBoss Logging release including a module descriptor (jboss-logging/jboss-logging#45)
- [x] https://github.com/jboss-logging/jboss-logging/pull/102
- [x] https://github.com/wildfly/wildfly-common/pull/104
- [x] https://github.com/jboss-logging/jboss-logging-tools/pull/116