### PR TITLE
Add scheduling capabilities to `EnhancedQueueExecutor`

### DIFF
--- a/src/test/java/org/jboss/threads/ArrayQueueTests.java
+++ b/src/test/java/org/jboss/threads/ArrayQueueTests.java
@@ -1,0 +1,247 @@
+package org.jboss.threads;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ArrayQueueTests {
+
+    static EnhancedQueueExecutor eqe;
+
+    static EnhancedQueueExecutor.AbstractScheduledFuture<?>[] ITEMS;
+
+    @BeforeClass
+    public static void beforeAll() {
+        eqe = new EnhancedQueueExecutor.Builder().build();
+        ITEMS = new EnhancedQueueExecutor.AbstractScheduledFuture[32];
+        for (int i = 0; i < 32; i ++) {
+            final String toString = "[" + i + "]";
+            ITEMS[i] = eqe.new RunnableScheduledFuture(new Runnable() {
+                public void run() {
+                    // nothing
+                }
+
+                public String toString() {
+                    return toString;
+                }
+            }, 0, TimeUnit.DAYS);
+        }
+    }
+
+    @Test
+    public void testMoveForward() {
+        EnhancedQueueExecutor.ArrayQueue aq = new EnhancedQueueExecutor.ArrayQueue(16);
+
+        int head = 5;
+        aq.testPoint_setHead(head);
+        aq.testPoint_setArrayItem(head + 0, ITEMS[0]);
+        aq.testPoint_setArrayItem(head + 1, ITEMS[1]);
+        aq.testPoint_setArrayItem(head + 2, ITEMS[2]);
+        aq.testPoint_setArrayItem(head + 3, ITEMS[3]);
+        aq.testPoint_setSize(4);
+
+        aq.moveForward(2, ITEMS[4]);
+
+        assertEquals(head, aq.testPoint_head());
+
+        assertSame(ITEMS[0], aq.testPoint_getArrayItem(head + 0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(head + 1));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(head + 2));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(head + 3));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(head + 4));
+    }
+
+    @Test
+    public void testMoveForwardWrap() {
+        EnhancedQueueExecutor.ArrayQueue aq = new EnhancedQueueExecutor.ArrayQueue(16);
+
+        int head = 14;
+        aq.testPoint_setHead(head);
+        aq.testPoint_setArrayItem(head + 0, ITEMS[0]);
+        aq.testPoint_setArrayItem(head + 1, ITEMS[1]);
+        aq.testPoint_setArrayItem(head + 2, ITEMS[2]);
+        aq.testPoint_setArrayItem(head + 3, ITEMS[3]);
+        aq.testPoint_setSize(4);
+
+        aq.moveForward(2, ITEMS[4]);
+
+        assertEquals(head, aq.testPoint_head());
+
+        assertSame(ITEMS[0], aq.testPoint_getArrayItem(head + 0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(head + 1));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(head + 2));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(head + 3));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(head + 4));
+    }
+
+    @Test
+    public void testMoveBackward() {
+        EnhancedQueueExecutor.ArrayQueue aq = new EnhancedQueueExecutor.ArrayQueue(16);
+
+        int head = 5;
+        aq.testPoint_setHead(head);
+        aq.testPoint_setArrayItem(head + 0, ITEMS[0]);
+        aq.testPoint_setArrayItem(head + 1, ITEMS[1]);
+        aq.testPoint_setArrayItem(head + 2, ITEMS[2]);
+        aq.testPoint_setArrayItem(head + 3, ITEMS[3]);
+        aq.testPoint_setSize(4);
+
+        aq.moveBackward(2, ITEMS[4]);
+
+        assertEquals(head - 1, aq.testPoint_head());
+        head--;
+
+        assertSame(ITEMS[0], aq.testPoint_getArrayItem(head + 0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(head + 1));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(head + 2));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(head + 3));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(head + 4));
+    }
+
+    @Test
+    public void testMoveBackwardWrap() {
+        EnhancedQueueExecutor.ArrayQueue aq = new EnhancedQueueExecutor.ArrayQueue(16);
+
+        int head = 14;
+        aq.testPoint_setHead(head);
+        aq.testPoint_setArrayItem(head + 0, ITEMS[0]);
+        aq.testPoint_setArrayItem(head + 1, ITEMS[1]);
+        aq.testPoint_setArrayItem(head + 2, ITEMS[2]);
+        aq.testPoint_setArrayItem(head + 3, ITEMS[3]);
+        aq.testPoint_setSize(4);
+
+        aq.moveBackward(2, ITEMS[4]);
+
+        assertEquals(head - 1, aq.testPoint_head());
+        head--;
+
+        assertSame(ITEMS[0], aq.testPoint_getArrayItem(head + 0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(head + 1));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(head + 2));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(head + 3));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(head + 4));
+    }
+
+    @Test
+    public void testQueueBehavior() {
+        EnhancedQueueExecutor.ArrayQueue aq = new EnhancedQueueExecutor.ArrayQueue(16);
+
+        // tc 0 (n/a)
+        assertTrue(aq.isEmpty());
+        assertEquals(0, aq.size());
+        assertEquals(0, aq.testPoint_head());
+        assertEquals(16, aq.testPoint_arrayLength());
+
+        // tc 1
+        aq.insertAt(0, ITEMS[0]);
+        assertFalse(aq.isEmpty());
+        assertEquals(1, aq.size());
+        assertEquals(0, aq.testPoint_head());
+        assertSame(ITEMS[0], aq.testPoint_getArrayItem(0));
+        assertNull(aq.testPoint_getArrayItem(1));
+        assertNull(aq.testPoint_getArrayItem(15));
+
+        // removal
+        assertSame(ITEMS[0], aq.pollFirst());
+        assertTrue(aq.isEmpty());
+        assertEquals(0, aq.size());
+        assertEquals(1, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(0));
+        assertNull(aq.testPoint_getArrayItem(1));
+
+        // tc 1 (but this time with head == 1)
+        aq.insertAt(0, ITEMS[1]);
+        assertFalse(aq.isEmpty());
+        assertEquals(1, aq.size());
+        assertEquals(1, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertNull(aq.testPoint_getArrayItem(2));
+
+        // tc 1 (but with head == 1 and size == 1)
+        aq.insertAt(1, ITEMS[2]);
+        assertFalse(aq.isEmpty());
+        assertEquals(2, aq.size());
+        assertEquals(1, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+
+        // tc 2 (but with head == 1 and size == 2)
+        aq.insertAt(0, ITEMS[3]);
+        assertFalse(aq.isEmpty());
+        assertEquals(3, aq.size()); // halfSize == 2
+        // head moves back to 0
+        assertEquals(0, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(15));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+
+        // tc 2 (but with head == 0 and size == 3)
+        aq.insertAt(0, ITEMS[4]);
+        assertFalse(aq.isEmpty());
+        assertEquals(4, aq.size());
+        // head wraps around to 15
+        assertEquals(15, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(14));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(15));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+
+        // tc 2 (but with head == 15 and size == 4)
+        aq.insertAt(0, ITEMS[5]);
+        assertFalse(aq.isEmpty());
+        assertEquals(5, aq.size());
+        assertEquals(14, aq.testPoint_head());
+        assertNull(aq.testPoint_getArrayItem(13));
+        assertSame(ITEMS[5], aq.testPoint_getArrayItem(14));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(15));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+
+        // tc
+        aq.insertAt(1, ITEMS[6]);
+
+        assertNull(aq.testPoint_getArrayItem(12));
+        assertSame(ITEMS[5], aq.testPoint_getArrayItem(13));
+        assertSame(ITEMS[6], aq.testPoint_getArrayItem(14));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(15));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+
+        aq.insertAt(0, ITEMS[7]);
+
+        assertNull(aq.testPoint_getArrayItem(11));
+        assertSame(ITEMS[7], aq.testPoint_getArrayItem(12));
+        assertSame(ITEMS[5], aq.testPoint_getArrayItem(13));
+        assertSame(ITEMS[6], aq.testPoint_getArrayItem(14));
+        assertSame(ITEMS[4], aq.testPoint_getArrayItem(15));
+        assertSame(ITEMS[3], aq.testPoint_getArrayItem(0));
+        assertSame(ITEMS[1], aq.testPoint_getArrayItem(1));
+        assertSame(ITEMS[2], aq.testPoint_getArrayItem(2));
+        assertNull(aq.testPoint_getArrayItem(3));
+    }
+
+    @AfterClass
+    public static void afterAll() throws InterruptedException {
+        try {
+            eqe.shutdown();
+            eqe.awaitTermination(30, TimeUnit.SECONDS);
+        } finally {
+            eqe = null;
+        }
+    }
+}

--- a/src/test/java/org/jboss/threads/ScheduledEnhancedQueueExecutorTest.java
+++ b/src/test/java/org/jboss/threads/ScheduledEnhancedQueueExecutorTest.java
@@ -1,0 +1,167 @@
+package org.jboss.threads;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+public class ScheduledEnhancedQueueExecutorTest {
+
+    @Test
+    public void testCancel() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            ScheduledFuture<?> future = eqe.schedule(() -> fail("Should never run"), 1000, TimeUnit.DAYS);
+            Thread.sleep(400); // a few ms to let things percolate
+            assertFalse(future.isCancelled());
+            // this should succeed since the task isn't submitted yet
+            assertTrue(future.cancel(false));
+            assertTrue(future.isCancelled());
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCancelWhileRunning() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            ScheduledFuture<Boolean> future = eqe.schedule(() -> { latch.countDown(); Thread.sleep(1_000_000_000L); return Boolean.TRUE; }, 1, TimeUnit.NANOSECONDS);
+            assertTrue("Timely task execution", latch.await(5, TimeUnit.SECONDS));
+            assertFalse(future.isCancelled());
+            // task is running; cancel will fail
+            assertFalse(future.cancel(false));
+            assertFalse(future.isCancelled());
+            assertFalse(future.isDone());
+            // now try to interrupt it (cancel still fails but the interrupt should be delivered)
+            assertFalse(future.cancel(true));
+            assertFalse(future.isCancelled());
+            // now get it
+            try {
+                future.get(100L, TimeUnit.MILLISECONDS);
+                fail("Expected exception");
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause();
+                assertTrue("Expected " + cause + " to be an InterruptedException", cause instanceof InterruptedException);
+            }
+            assertTrue(future.isDone());
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testReasonableExecutionDelay() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            Callable<Boolean> task = () -> Boolean.TRUE;
+            long start = System.nanoTime();
+            ScheduledFuture<Boolean> future = eqe.schedule(task, 1, TimeUnit.MILLISECONDS);
+            Boolean result = future.get();
+            long execTime = System.nanoTime() - start;
+            long expected = 1_000_000L;
+            assertTrue("Execution too short (expected at least " + expected + ", got " + execTime + ")", execTime >= expected);
+            assertNotNull(result);
+            assertTrue(result.booleanValue());
+            start = System.nanoTime();
+            future = eqe.schedule(task, 500, TimeUnit.MILLISECONDS);
+            result = future.get();
+            execTime = System.nanoTime() - start;
+            expected = 500_000_000L;
+            assertTrue("Execution too short (expected at least " + expected + ", got " + execTime + ")", execTime >= expected);
+            assertNotNull(result);
+            assertTrue(result.booleanValue());
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testFixedRateExecution() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            AtomicInteger ai = new AtomicInteger();
+            CountDownLatch completeLatch = new CountDownLatch(1);
+            ScheduledFuture<?> future = eqe.scheduleAtFixedRate(() -> {
+                if (ai.incrementAndGet() == 5) {
+                    completeLatch.countDown();
+                }
+            }, 20, 50, TimeUnit.MILLISECONDS);
+            assertTrue("Completion of enough iterations", completeLatch.await(1, TimeUnit.SECONDS));
+            assertFalse(future.isDone()); // they're never done
+            // don't assert, because there's a small chance it would happen to be running
+            future.cancel(false);
+            try {
+                future.get(1, TimeUnit.SECONDS);
+                fail("Expected cancellation exception");
+            } catch (CancellationException e) {
+                // expected
+            }
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testFixedDelayExecution() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            AtomicInteger ai = new AtomicInteger();
+            CountDownLatch completeLatch = new CountDownLatch(1);
+            ScheduledFuture<?> future = eqe.scheduleWithFixedDelay(() -> {
+                if (ai.incrementAndGet() == 5) {
+                    completeLatch.countDown();
+                }
+            }, 20, 50, TimeUnit.MILLISECONDS);
+            assertTrue("Completion of enough iterations", completeLatch.await(1, TimeUnit.SECONDS));
+            assertFalse(future.isDone()); // they're never done
+            // don't assert, because there's a small chance it would happen to be running
+            future.cancel(false);
+            try {
+                future.get(1, TimeUnit.SECONDS);
+                fail("Expected cancellation exception");
+            } catch (CancellationException e) {
+                // expected
+            }
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCancelOnShutdown() throws Exception {
+        EnhancedQueueExecutor eqe = new EnhancedQueueExecutor.Builder().build();
+        try {
+            ScheduledFuture<?> future = eqe.schedule(() -> fail("Should never run"), 1, TimeUnit.DAYS);
+            eqe.shutdown();
+            assertTrue("Timely shutdown", eqe.awaitTermination(5, TimeUnit.SECONDS));
+            try {
+                future.get(1, TimeUnit.SECONDS);
+                fail("Expected cancellation exception");
+            } catch (CancellationException e) {
+                // expected
+            }
+            assertTrue("Was cancelled on shutdown", future.isCancelled());
+        } finally {
+            eqe.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
This is an initial prototype with the following features:

- Enhance `EnhancedQueueExecutor` to implement `ScheduledExecutorService` directly
- Use a dedicated scheduling thread
- ~~The scheduled work queue is a simple sorted `ArrayList` (I expect this to perform substantially better than e.g. `TreeSet` up to a certain size... but I don't know what size that might be)~~ [UPDATE: Just using a `TreeSet` for now, until a more optimal array-based structure can be thoroughly vetted]
- Uses the internal `Task` structure to capture the calling context and also to avoid creating more wrapper objects than strictly necessary
- ~~Uses thread monitor `wait`/`notify` which may only have millisecond resolution on some JDKs~~ [UPDATE: Now using `ReentrantLock` for the main queue; for the `Future` itself it doesn't matter as much]
- Forbids comparison via `Delayed` interface with any other implementations
- ~~Tasks with same execution time compare to `0`~~ [UPDATE: Each task now has a uniquifying sequence number]
- ~~Manually tested some basic cases~~ [UPDATE: There are unit tests now]
- Malfunctions after about 292 years of running

I want to pursue (at a minimum) the following before finalizing the PR:
- [x] Lazily start the scheduling thread
- [x] Make the scheduled work queue automatically switch from `ArrayList` to e.g. `TreeSet` (or something better that is still no worse than `O(log n)` for insertions and `O(log n)` for head removals) once it reaches a certain size
- [x] Pre-size the `ArrayList` to a logical fraction of the "certain size" so that it resizes exactly zero, one, or two times before switching to an alternative data structure
- [x] Maybe move to `ReentrantLock`/`Condition` for the work queue so that tasks can wait with higher resolution than millisecond
- [ ] Investigate aggressive removal from the scheduled work queue on cancellation (maybe do this as a later enhancement)
- [x] Consider introducing a serial number so that every task sorts uniquely
- [x] Introduce comprehensive unit tests
- [x] Get feedback from @jponge and @cescoffier
