### PR TITLE
Clean up compilation warnings

### DIFF
--- a/src/main/java/org/jboss/threads/JBossExecutors.java
+++ b/src/main/java/org/jboss/threads/JBossExecutors.java
@@ -17,6 +17,7 @@ import sun.misc.Unsafe;
 /**
  * JBoss thread- and executor-related utility and factory methods.
  */
+@SuppressWarnings("deprecation")
 public final class JBossExecutors {
 
     private static final Logger THREAD_ERROR_LOGGER = Logger.getLogger("org.jboss.threads.errors");

--- a/src/main/java/org/jboss/threads/JBossThreadFactory.java
+++ b/src/main/java/org/jboss/threads/JBossThreadFactory.java
@@ -58,6 +58,7 @@ public final class JBossThreadFactory implements ThreadFactory {
     /**
      * @deprecated Use {@link #JBossThreadFactory(ThreadGroup, Boolean, Integer, String, Thread.UncaughtExceptionHandler, Long)} instead.
      */
+    @Deprecated
     public JBossThreadFactory(ThreadGroup threadGroup, final Boolean daemon, final Integer initialPriority, String namePattern, final Thread.UncaughtExceptionHandler uncaughtExceptionHandler, final Long stackSize, final AccessControlContext ignored) {
         this(threadGroup, daemon, initialPriority, namePattern, uncaughtExceptionHandler, stackSize);
     }

--- a/src/main/java/org/jboss/threads/Messages.java
+++ b/src/main/java/org/jboss/threads/Messages.java
@@ -1,5 +1,7 @@
 package org.jboss.threads;
 
+import java.time.Duration;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -63,9 +65,7 @@ interface Messages extends BasicLogger {
     @Message(id = 103, value = "The current thread does not support interrupt handlers")
     IllegalStateException noInterruptHandlers();
 
-    @Message(id = 104, value = "Executor is not shut down")
-    @Deprecated
-    IllegalStateException notShutDown();
+//    @Message(id = 104, value = "Executor is not shut down")
 
 //    @Message(id = 105, value = "Concurrent modification of collection detected")
 
@@ -76,6 +76,9 @@ interface Messages extends BasicLogger {
     @Message(id = 108, value = "Interrupt handler %s threw an exception")
     @LogMessage(level = Logger.Level.ERROR)
     void interruptHandlerThrew(@Cause Throwable cause, InterruptHandler interruptHandler);
+
+    @Message(id = 109, value = "Keep-alive time must be positive but was %s")
+    IllegalArgumentException nonPositiveKeepAlive(Duration actual);
 
     // security
 

--- a/src/test/java/org/jboss/threads/EnhancedQueueExecutorTest.java
+++ b/src/test/java/org/jboss/threads/EnhancedQueueExecutorTest.java
@@ -3,6 +3,7 @@ package org.jboss.threads;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -52,7 +53,7 @@ public class EnhancedQueueExecutorTest {
     @Disabled("https://issues.jboss.org/browse/JBTHR-67")
     public void testThreadReuse() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -81,7 +82,7 @@ public class EnhancedQueueExecutorTest {
     @Disabled("https://issues.jboss.org/browse/JBTHR-67")
     public void testKeepaliveTime() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -104,7 +105,7 @@ public class EnhancedQueueExecutorTest {
     @Disabled("https://issues.jboss.org/browse/JBTHR-67")
     public void testKeepaliveTime2() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(coreSize)
                 .build();
@@ -126,7 +127,7 @@ public class EnhancedQueueExecutorTest {
     @Disabled("https://issues.jboss.org/browse/JBTHR-67")
     public void testKeepaliveTime3() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .allowCoreThreadTimeOut(true)
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
@@ -146,7 +147,7 @@ public class EnhancedQueueExecutorTest {
     @Test
     public void testPrestartCoreThreads() {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -165,7 +166,7 @@ public class EnhancedQueueExecutorTest {
         assertStackDepth(new EnhancedQueueExecutor.Builder()
                 .setCorePoolSize(1)
                 .setMaximumPoolSize(1)
-                .build(), expectedStackFrames + 1);
+                .build(), expectedStackFrames + 2);
         // Use a standard ThreadPoolExecutor as a baseline for comparison.
         assertStackDepth(Executors.newSingleThreadExecutor(), expectedStackFrames);
     }

--- a/src/test/java/org/jboss/threads/EnhancedThreadQueueExecutorTestCase.java
+++ b/src/test/java/org/jboss/threads/EnhancedThreadQueueExecutorTestCase.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -51,18 +52,17 @@ public class EnhancedThreadQueueExecutorTestCase {
     public void testInvalidValuesKeepAliveZero() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                         .isThrownBy(() -> new EnhancedQueueExecutor.Builder()
-                .setKeepAliveTime(0, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ZERO)
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build());
-        ;
     }
 
     @Test
     public void testInvalidValuesKeepAliveNegative() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new EnhancedQueueExecutor.Builder()
-                .setKeepAliveTime(-3456, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(-3456))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build());
@@ -72,7 +72,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     public void testInvalidValuesCoreSizeNegative() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new EnhancedQueueExecutor.Builder()
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(-5)
                 .setMaximumPoolSize(maxSize)
                 .build());
@@ -82,7 +82,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     public void testInvalidValuesMaxSizeNegative() {
         Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new EnhancedQueueExecutor.Builder()
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(-3)
                 .build());
@@ -92,7 +92,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     public void testCoreSizeBiggerThanMaxSize() {
         int expectedCorePoolSize = 5;
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(2 * expectedCorePoolSize)
                 .setMaximumPoolSize(expectedCorePoolSize)
                 .build();
@@ -110,7 +110,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Test
     public void testThreadReuse() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -154,7 +154,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Disabled("This test consistently fails, see JBTHR-67")
     public void testThreadReuseAboveCoreSize() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(60000, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofSeconds(60))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -202,7 +202,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Disabled("This test consistently fails, see JBTHR-67")
     public void testKeepaliveTime() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .allowCoreThreadTimeOut(false)
@@ -241,7 +241,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Test
     public void testKeepaliveTime2() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(coreSize)
                 .build();
@@ -267,7 +267,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Test
     public void testKeepaliveTimeWithCoreThreadTimeoutEnabled() throws TimeoutException, InterruptedException {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .allowCoreThreadTimeOut(true)
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
@@ -294,7 +294,7 @@ public class EnhancedThreadQueueExecutorTestCase {
     @Test
     public void testPrestartCoreThreads() {
         EnhancedQueueExecutor executor = (new EnhancedQueueExecutor.Builder())
-                .setKeepAliveTime(keepaliveTimeMillis, TimeUnit.MILLISECONDS)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
                 .setCorePoolSize(coreSize)
                 .setMaximumPoolSize(maxSize)
                 .build();
@@ -341,7 +341,7 @@ public class EnhancedThreadQueueExecutorTestCase {
         final CountDownLatch terminateLatch = new CountDownLatch(1);
         EnhancedQueueExecutor executor = new EnhancedQueueExecutor.Builder()
                 .setCorePoolSize(10)
-                .setKeepAliveTime(1, TimeUnit.NANOSECONDS)
+                .setKeepAliveTime(Duration.ofNanos(1))
                 .setTerminationTask(new Runnable() {
                     @Override
                     public void run() {
@@ -359,7 +359,7 @@ public class EnhancedThreadQueueExecutorTestCase {
         final CountDownLatch terminateLatch = new CountDownLatch(1);
         EnhancedQueueExecutor executor = new EnhancedQueueExecutor.Builder()
                 .setCorePoolSize(10)
-                .setKeepAliveTime(1, TimeUnit.NANOSECONDS)
+                .setKeepAliveTime(Duration.ofNanos(1))
                 .setTerminationTask(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
There are several compilation warnings that we can clean up, mostly regarding deprecated member access and unchecked generics usage.