### PR TITLE
Uses 128 bytes padding to prevent false-sharing

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -333,16 +333,18 @@ public final class EnhancedQueueExecutor extends AbstractExecutorService impleme
                 // guess
                 cacheLine = 64;
             }
+            // cpu spatial prefetcher can drag 2 cache-lines at once into L2
+            int pad = cacheLine > 128 ? cacheLine : 128;
             int longScale = unsafe.arrayIndexScale(long[].class);
             int objScale = unsafe.arrayIndexScale(Object[].class);
             // these fields are in units of array scale
-            unsharedObjectsSize = cacheLine / objScale * (numUnsharedObjects + 1);
-            unsharedLongsSize = cacheLine / longScale * (numUnsharedLongs + 1);
+            unsharedObjectsSize = pad / objScale * (numUnsharedObjects + 1);
+            unsharedLongsSize = pad / longScale * (numUnsharedLongs + 1);
             // these fields are in bytes
-            headOffset = unsafe.arrayBaseOffset(Object[].class) + cacheLine;
-            tailOffset = unsafe.arrayBaseOffset(Object[].class) + cacheLine * 2;
-            threadStatusOffset = unsafe.arrayBaseOffset(long[].class) + cacheLine;
-            queueSizeOffset = unsafe.arrayBaseOffset(long[].class) + cacheLine * 2;
+            headOffset = unsafe.arrayBaseOffset(Object[].class) + pad;
+            tailOffset = unsafe.arrayBaseOffset(Object[].class) + pad * 2;
+            threadStatusOffset = unsafe.arrayBaseOffset(long[].class) + pad;
+            queueSizeOffset = unsafe.arrayBaseOffset(long[].class) + pad * 2;
         }
     }
 


### PR DESCRIPTION
According to [Intel Optimisation Manual](https://www.intel.com/content/www/us/en/content-details/671488/intel-64-and-ia-32-architectures-optimization-reference-manual-volume-1.html), using 128 bytes is safer due to the spatial prefetcher - which can bring 2 cache-lines into L2.

see

![image](https://github.com/user-attachments/assets/0497bcf1-c199-4515-91cd-e7cd5cef0358)

Intel Netburst is pretty old but I've observed something similar with AMD Ryzen with multi-NUMA nodes.

See https://morestina.net/blog/1976/a-close-encounter-with-false-sharing as well

I've been hit by the same in Hyperfoil too, see https://github.com/Hyperfoil/Hyperfoil/pull/374/files#diff-03478637fd75a5eb1aef7f5db3b19db102359afba797e0328580dcc83796b735R40

OpenJDK itself seems to prefer 128 bytes: https://github.com/openjdk/jdk/blob/44024826e52373d1613ec366e3f5a9d5bbaefa41/src/hotspot/share/runtime/globals.hpp#L811

and fallback to the cache line only if the cache line exceed the configured default one, see https://github.com/openjdk/jdk/blob/44024826e52373d1613ec366e3f5a9d5bbaefa41/src/hotspot/cpu/x86/vm_version_x86.cpp#L1940-L1942

