### PR TITLE
Embed native-image configuration file

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -322,7 +322,10 @@ public final class EnhancedQueueExecutor extends AbstractExecutorService impleme
     private static final long activeCountOffset;
     private static final long peakQueueSizeOffset;
 
-    // GraalVM should initialize this class at run time
+    // GraalVM should initialize this class at run time, which we instruct it to do in
+    // src/main/resources/META-INF/native-image/org.jboss.threads/jboss-threads/native-image.properties
+    // Please make sure to update that file if you remove or rename this class, or if runtime
+    // initialization is no longer needed
     private static final class RuntimeFields {
         private static final int unsharedTaskNodesSize;
         private static final int unsharedLongsSize;

--- a/src/main/resources/META-INF/native-image/org.jboss.threads/jboss-threads/native-image.properties
+++ b/src/main/resources/META-INF/native-image/org.jboss.threads/jboss-threads/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=org.jboss.threads.EnhancedQueueExecutor$RuntimeFields


### PR DESCRIPTION
See https://www.graalvm.org/jdk21/reference-manual/native-image/overview/BuildConfiguration/#embed-a-configuration-file

This way consumers of the maven artifact won't need to manually register the said class for runtime initialization (i.e. https://github.com/quarkusio/quarkus/pull/43798 and similar PRs become redundant)
