### PR TITLE
Don't load Version class unless logging is enabled

### DIFF
--- a/src/main/java/org/jboss/threads/JBossThread.java
+++ b/src/main/java/org/jboss/threads/JBossThread.java
@@ -34,7 +34,9 @@ public class JBossThread extends Thread {
     }).intValue();
 
     static {
-        Version.getVersionString();
+        if (VersionLogging.shouldLogVersion()) {
+            Version.getVersionString();
+        }
     }
 
     private volatile InterruptHandler interruptHandler;

--- a/src/main/java/org/jboss/threads/Version.java
+++ b/src/main/java/org/jboss/threads/Version.java
@@ -32,18 +32,10 @@ public final class Version {
         }
         JAR_NAME = jarName;
         VERSION_STRING = versionString;
-        boolean logVersion = AccessController.doPrivileged((PrivilegedAction<Boolean>) Version::shouldLogVersion).booleanValue();
+        boolean logVersion = AccessController.doPrivileged((PrivilegedAction<Boolean>) VersionLogging::shouldLogVersion).booleanValue();
         if (logVersion) try {
             Messages.msg.version(versionString);
         } catch (Throwable ignored) {}
-    }
-
-    private static Boolean shouldLogVersion() {
-        try {
-            return Boolean.valueOf(System.getProperty("jboss.log-version", "true"));
-        } catch (Throwable ignored) {
-            return Boolean.FALSE;
-        }
     }
 
     /**

--- a/src/main/java/org/jboss/threads/VersionLogging.java
+++ b/src/main/java/org/jboss/threads/VersionLogging.java
@@ -1,0 +1,15 @@
+package org.jboss.threads;
+
+/**
+ * Not part of {@link Version} in order to not force class initialization of the latter
+ */
+class VersionLogging {
+
+    static Boolean shouldLogVersion() {
+        try {
+            return Boolean.valueOf(System.getProperty("jboss.log-version", "true"));
+        } catch (Throwable ignored) {
+            return Boolean.FALSE;
+        }
+    }
+}


### PR DESCRIPTION
In Quarkus, version logging is [disabled](https://github.com/quarkusio/quarkus/blob/3.17.5/core/runtime/src/main/java/io/quarkus/runtime/logging/JBossVersion.java#L10) so there is no reason to pay the (admittedly small but not zero) price of loading the class

P.S. I don't see any other side effects that loading the class might have, but I'd welcome more info if there are