### PR TITLE
Remove usages of `Unsafe`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         java-version: |
           17
           21
+          24
 
     - name: Build with Maven
-      run: mvn verify -ntp -B "-Djava17.home=${{env.JAVA_HOME_17_X64}}${{env.JAVA_HOME_17_ARM64}}"
+      run: mvn verify -ntp -B "-Djava17.home=${{env.JAVA_HOME_17_X64}}${{env.JAVA_HOME_17_ARM64}}" "-Djava21.home=${{env.JAVA_HOME_21_X64}}${{env.JAVA_HOME_21_ARM64}}"

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <jboss.threads.eqe.unlimited-queue>false</jboss.threads.eqe.unlimited-queue>
         <jboss.threads.eqe.register-mbean>false</jboss.threads.eqe.register-mbean>
 
-        <jdk.min.version>11</jdk.min.version>
+        <jdk.min.version>24</jdk.min.version>
 
         <version.jboss.logging.tools>3.0.4.Final</version.jboss.logging.tools>
     </properties>

--- a/src/main/java/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java/org/jboss/threads/JDKSpecific.java
@@ -1,0 +1,71 @@
+package org.jboss.threads;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import sun.misc.Unsafe;
+
+final class JDKSpecific {
+    private JDKSpecific() {}
+
+    private static final Unsafe unsafe;
+    private static final long contextClassLoaderOffs;
+
+    static {
+        unsafe = AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
+            public Unsafe run() {
+                try {
+                    Field field = Unsafe.class.getDeclaredField("theUnsafe");
+                    field.setAccessible(true);
+                    return (Unsafe) field.get(null);
+                } catch (IllegalAccessException e) {
+                    IllegalAccessError error = new IllegalAccessError(e.getMessage());
+                    error.setStackTrace(e.getStackTrace());
+                    throw error;
+                } catch (NoSuchFieldException e) {
+                    NoSuchFieldError error = new NoSuchFieldError(e.getMessage());
+                    error.setStackTrace(e.getStackTrace());
+                    throw error;
+                }
+            }
+        });
+        try {
+            contextClassLoaderOffs = unsafe.objectFieldOffset(Thread.class.getDeclaredField("contextClassLoader"));
+        } catch (NoSuchFieldException e) {
+            NoSuchFieldError error = new NoSuchFieldError(e.getMessage());
+            error.setStackTrace(e.getStackTrace());
+            throw error;
+        }
+    }
+
+    static void setThreadContextClassLoader(Thread thread, ClassLoader classLoader) {
+        unsafe.putObject(thread, contextClassLoaderOffs, classLoader);
+    }
+
+    static ClassLoader getThreadContextClassLoader(Thread thread) {
+        return (ClassLoader) unsafe.getObject(thread, contextClassLoaderOffs);
+    }
+
+    static final class ThreadAccess {
+        private static final long threadLocalMapOffs;
+        private static final long inheritableThreadLocalMapOffs;
+
+        static {
+            try {
+                threadLocalMapOffs = unsafe.objectFieldOffset(Thread.class.getDeclaredField("threadLocals"));
+                inheritableThreadLocalMapOffs = unsafe.objectFieldOffset(Thread.class.getDeclaredField("inheritableThreadLocals"));
+            } catch (NoSuchFieldException e) {
+                NoSuchFieldError error = new NoSuchFieldError(e.getMessage());
+                error.setStackTrace(e.getStackTrace());
+                throw error;
+            }
+        }
+
+        static void clearThreadLocals() {
+            Thread thread = Thread.currentThread();
+            unsafe.putObject(thread, threadLocalMapOffs, null);
+            unsafe.putObject(thread, inheritableThreadLocalMapOffs, null);
+        }
+    }
+}

--- a/src/main/java/org/jboss/threads/ThreadLocalResettingRunnable.java
+++ b/src/main/java/org/jboss/threads/ThreadLocalResettingRunnable.java
@@ -10,31 +10,11 @@ final class ThreadLocalResettingRunnable extends DelegatingRunnable {
         try {
             super.run();
         } finally {
-            Resetter.run();
+            JDKSpecific.ThreadAccess.clearThreadLocals();
         }
     }
 
     public String toString() {
         return "Thread-local resetting Runnable";
-    }
-
-    static final class Resetter {
-        private static final long threadLocalMapOffs;
-        private static final long inheritableThreadLocalMapOffs;
-
-        static {
-            try {
-                threadLocalMapOffs = JBossExecutors.unsafe.objectFieldOffset(Thread.class.getDeclaredField("threadLocals"));
-                inheritableThreadLocalMapOffs = JBossExecutors.unsafe.objectFieldOffset(Thread.class.getDeclaredField("inheritableThreadLocals"));
-            } catch (NoSuchFieldException e) {
-                throw new NoSuchFieldError(e.getMessage());
-            }
-        }
-
-        static void run() {
-            final Thread thread = Thread.currentThread();
-            JBossExecutors.unsafe.putObject(thread, threadLocalMapOffs, null);
-            JBossExecutors.unsafe.putObject(thread, inheritableThreadLocalMapOffs, null);
-        }
     }
 }

--- a/src/main/java24/org/jboss/threads/JDKSpecific.java
+++ b/src/main/java24/org/jboss/threads/JDKSpecific.java
@@ -1,0 +1,51 @@
+package org.jboss.threads;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.UndeclaredThrowableException;
+
+final class JDKSpecific {
+    private JDKSpecific() {}
+
+    static void setThreadContextClassLoader(Thread thread, ClassLoader classLoader) {
+        thread.setContextClassLoader(classLoader);
+    }
+
+    static ClassLoader getThreadContextClassLoader(Thread thread) {
+        return thread.getContextClassLoader();
+    }
+
+    static final class ThreadAccess {
+        private static final MethodHandle setThreadLocalsHandle;
+        private static final MethodHandle setInheritableThreadLocalsHandle;
+
+        static {
+            try {
+                MethodHandles.Lookup threadLookup = MethodHandles.privateLookupIn(Thread.class, MethodHandles.lookup());
+                setThreadLocalsHandle = threadLookup.unreflectVarHandle(Thread.class.getDeclaredField("threadLocals")).toMethodHandle(VarHandle.AccessMode.SET).asType(MethodType.methodType(void.class, Object.class));
+                setInheritableThreadLocalsHandle = threadLookup.unreflectVarHandle(Thread.class.getDeclaredField("inheritableThreadLocals")).toMethodHandle(VarHandle.AccessMode.SET).asType(MethodType.methodType(void.class, Object.class));
+            } catch (IllegalAccessException e) {
+                Module myModule = ThreadAccess.class.getModule();
+                String myName = myModule.isNamed() ? myModule.getName() : "ALL-UNNAMED";
+                throw new IllegalAccessError(e.getMessage() +
+                    "; to use the thread-local-reset capability on Java 24 or later, use this JVM option: --add-opens java.base/java.lang=" + myName);
+            } catch (NoSuchFieldException e) {
+                throw new NoSuchFieldError(e.getMessage());
+            }
+        }
+
+        static void clearThreadLocals() {
+            final Thread thread = Thread.currentThread();
+            try {
+                setThreadLocalsHandle.invokeExact(thread, null);
+                setInheritableThreadLocalsHandle.invokeExact(thread, null);
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new UndeclaredThrowableException(t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Remove all usages of `Unsafe` in favor of supported APIs.

To use the thread-local resetter will now require `--add-opens java.base/java.lang=org.jboss.threads` (or `ALL-UNNAMED` if not using JDK modules).

Java 25+ reports this:
```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.jboss.threads.JBossExecutors (jar:file:/Volumes/Case-sensitive/david/.../org/jboss/threads/jboss-threads-3.8.0.Final.jar!/org/jboss/threads/ContextHandler.class)
WARNING: Please consider reporting this to the maintainers of class org.jboss.threads.JBossExecutors
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```