### PR TITLE
[2.4] Add Duration-based setKeepAliveTime API to 2.4.x for Infinispan 15.0.…

### DIFF
--- a/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
+++ b/src/main/java/org/jboss/threads/EnhancedQueueExecutor.java
@@ -28,6 +28,7 @@ import static java.util.concurrent.locks.LockSupport.*;
 import java.lang.management.ManagementFactory;
 import java.security.AccessControlContext;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -552,6 +553,22 @@ public final class EnhancedQueueExecutor extends AbstractExecutorService impleme
             this.keepAliveTime = keepAliveTime;
             this.keepAliveUnits = keepAliveUnits;
             return this;
+        }
+
+        /**
+         * Set the thread keep-alive time using a {@link Duration}.
+         * <p>
+         * This method was added to provide API compatibility with Infinispan 15.0.19+, which uses
+         * the Duration-based API. It delegates to {@link #setKeepAliveTime(long, TimeUnit)}.
+         *
+         * @param keepAliveTime the thread keep-alive time (must not be {@code null})
+         * @return this builder
+         * @see EnhancedQueueExecutor#setKeepAliveTime(long, TimeUnit)
+         * @see EnhancedQueueExecutor#setKeepAliveTime(Duration)
+         */
+        public Builder setKeepAliveTime(final Duration keepAliveTime) {
+            Assert.checkNotNullParam("keepAliveTime", keepAliveTime);
+            return setKeepAliveTime(keepAliveTime.toNanos(), TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -1171,6 +1188,23 @@ public final class EnhancedQueueExecutor extends AbstractExecutorService impleme
         Assert.checkMinimumParameter("keepAliveTime", 1L, keepAliveTime);
         Assert.checkNotNullParam("keepAliveUnits", keepAliveUnits);
         timeoutNanos = max(1L, keepAliveUnits.toNanos(keepAliveTime));
+    }
+
+    /**
+     * Set the thread keep-alive time using a {@link Duration}. This is the minimum length of time that idle threads
+     * should remain until they exit. Unless core threads are allowed to time out, threads will only exit if the
+     * current thread count exceeds the core limit.
+     * <p>
+     * This method was added to provide API compatibility with Infinispan 15.0.19+, which uses
+     * the Duration-based API. It delegates to {@link #setKeepAliveTime(long, TimeUnit)}.
+     *
+     * @param keepAliveTime the thread keep-alive time (must not be {@code null})
+     * @see Builder#setKeepAliveTime(Duration) Builder.setKeepAliveTime()
+     * @see #setKeepAliveTime(long, TimeUnit)
+     */
+    public void setKeepAliveTime(final Duration keepAliveTime) {
+        Assert.checkNotNullParam("keepAliveTime", keepAliveTime);
+        setKeepAliveTime(keepAliveTime.toNanos(), TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/src/test/java/org/jboss/threads/EnhancedThreadQueueExecutorTestCase.java
+++ b/src/test/java/org/jboss/threads/EnhancedThreadQueueExecutorTestCase.java
@@ -18,6 +18,7 @@
 
 package org.jboss.threads;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -395,5 +396,33 @@ public class EnhancedThreadQueueExecutorTestCase {
         }
         executor.shutdown();
         Assert.assertTrue(terminateLatch.await(10, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Test that the Duration-based setKeepAliveTime method works correctly.
+     * This verifies compatibility with Infinispan 15.0.19+ which uses Duration API.
+     */
+    @Test
+    public void testSetKeepAliveTimeWithDuration() throws Exception {
+        // Test Builder.setKeepAliveTime(Duration)
+        EnhancedQueueExecutor executor = new EnhancedQueueExecutor.Builder()
+                .setCorePoolSize(coreSize)
+                .setMaximumPoolSize(maxSize)
+                .setKeepAliveTime(Duration.ofMillis(keepaliveTimeMillis))
+                .build();
+
+        // Verify the keepalive time was set correctly
+        long actualKeepAliveMillis = executor.getKeepAliveTime(TimeUnit.MILLISECONDS);
+        Assert.assertEquals("KeepAlive time should match the value set via Duration API",
+                keepaliveTimeMillis, actualKeepAliveMillis);
+
+        // Test runtime setKeepAliveTime(Duration) on the executor instance
+        long newKeepAliveMillis = 5000;
+        executor.setKeepAliveTime(Duration.ofMillis(newKeepAliveMillis));
+        actualKeepAliveMillis = executor.getKeepAliveTime(TimeUnit.MILLISECONDS);
+        Assert.assertEquals("KeepAlive time should match the value set via Duration API at runtime",
+                newKeepAliveMillis, actualKeepAliveMillis);
+
+        executor.shutdown();
     }
 }


### PR DESCRIPTION
…x compatibility

This commit adds java.time.Duration overloads for setKeepAliveTime methods to resolve API incompatibility between jboss-threads 2.4.x and Infinispan 15.0.19+.

Infinispan 15.0.19 (from RHDG 8.5.5) calls:
  builder.setKeepAliveTime(Duration.of(keepAlive, ChronoUnit.MILLIS))

But jboss-threads 2.4.0 only provides:
  setKeepAliveTime(long, TimeUnnit)

resulting in NoSuchMethodError